### PR TITLE
Buying Cows will No Longer Produce a Toast Message

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -61,10 +61,6 @@ export default function PlayPage() {
   // Stryker restore all 
 
 
-  const onSuccessBuy = () => {
-    toast(`Cow bought!`);
-  }
-
   // Stryker disable all (can't check if commonsId is null because it is mocked)
   const objectToAxiosParamsBuy = (newUserCommons) => ({
     url: "/api/usercommons/buy",

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -76,7 +76,7 @@ export default function PlayPage() {
   // Stryker disable all 
   const mutationbuy = useBackendMutation(
     objectToAxiosParamsBuy,
-    { onSuccess: onSuccessBuy },
+    null,
     // Stryker disable next-line all : hard to set up test for caching
     [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
   );

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -89,8 +89,6 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
 
-        expect(mockToast).toBeCalledWith("Cow bought!");
-
         const sellCowButton = screen.getByTestId("sell-cow-button");
         fireEvent.click(sellCowButton);
 


### PR DESCRIPTION
<!-- See https://github.com/ucsb-cs156-m23/m23-10am-4-NOTES/blob/main/masterDoc.md for more info-->
## Overview
This PR fixes the spam that buying cows creates. On buying a cow, the system will no longer show a toast msg that the cow can be bought. Other changes include removing calls to this function by others.

## Validation
1. Download this branch and run it on your localhost.
2. Login and try to buy a cow.
3. You should see that your cow inventory goes up, but no notification appears.

## Tests
<!--Add any additional tests or required tests-->
- [x] Unit tests pass
- [x] Test coverage is at 100%
- [x] Mutation tests show a rate of 100% 

## ChangeLog
<!--Every changed file should be listed here with a one-line description-->
- `frontend/src/main/pages/PlayPage.js` Removed const function that produces the toast message as well as backend mutation testing that depended on it.
- `frontend/src/tests/pages/PlayPage.test.js` Removed expectation for toast message in test.

## Linked Issues
<!--Issues related to the PR-->
Closes #7 