### PR TITLE
Leaderboard now shows total wealth in USD currency

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -4,7 +4,7 @@ import { hasRole } from "main/utils/currentUser";
 // should take in a players list from a commons
 export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
-    let USD = new Intl.NumberFormat("en-US", {
+    const USD = new Intl.NumberFormat("en-US", {
         style: "currency",
         currency: "USD"
     });

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -23,7 +23,11 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             id: 'totalWealth',
             accessor: (row, _rowIndex) => {
                 return USD.format(row.totalWealth);
-            }
+            },
+            Cell: (props) => {
+                return (
+                  <div style={{textAlign: "right"}}>{props.value}</div>)
+                  },
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -4,6 +4,11 @@ import { hasRole } from "main/utils/currentUser";
 // should take in a players list from a commons
 export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
 
+    let USD = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD"
+    });
+
     const columns = [
         {
             Header: 'User Id',
@@ -15,7 +20,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         },
         {
             Header: 'Total Wealth',
-            accessor: 'totalWealth',
+            id: 'totalWealth',
+            accessor: (row, _rowIndex) => {
+                return USD.format(row.totalWealth);
+            }
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -82,14 +82,14 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1,000.00");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsSold`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowDeaths`)).toHaveTextContent("5");

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -98,7 +98,6 @@ describe("LeaderboardTable tests", () => {
 
   test("Total wealth is formatted correctly", () => {
     const currentUser = currentUserFixtures.adminUser;
-    const testId = "LeaderboardTable";
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -96,5 +96,23 @@ describe("LeaderboardTable tests", () => {
 
   });
 
+  test("Total wealth is formatted correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const testId = "LeaderboardTable";
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+
+  });
+    
+
 });
 


### PR DESCRIPTION
<!-- See https://github.com/ucsb-cs156-m23/m23-10am-4-NOTES/blob/main/masterDoc.md for more info-->
## Overview
The react component has been updated to display the total wealth on the leaderboard in currency format. No underlying changes to the data have been made. Only the rendering react table file has been updated. 

## Screenshots
<img width="903" alt="Screenshot 2023-08-14 at 4 50 01 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/4ff35394-d09e-4aa5-b5bd-74ac8cd10873">



## Feedback Request
This method uses native javascript, so there should be no dependency issues. Please suggest if there are more elegant ways to do this, as this method requires a declaration and making another object. Ideally, it would be a one-liner, maybe some formatting that is native to React instead. 


## Validation
1. Download this branch and run the service locally.
2. Navigate to the leaderboard page.
3. You should see the total wealth column be displayed in USD currency format.

## Tests
<!--Add any additional tests or required tests-->
- [x] Unit tests pass
- [x] Test coverage is at 100%
- [x] Mutation tests show a rate of 100% 

## ChangeLog
<!--Every changed file should be listed here with a one-line description-->
*Note: some file changes here are from the previous pull request. As such, they will not be listed here.*
- `frontend/src/main/components/Leaderboard/LeaderboardTable.js` Created a USD currency object to format the total wealth column and updated the table entry to format the raw data into USD.
- `frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js` Tests now look for the USD currency.

## Linked Issues
<!--Issues related to the PR-->
Closes #2 