### PR TITLE
Degradation Rate Step is Now 0.001

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -139,7 +139,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
           data-testid={`${testid}-degradationRate`}
           id="degradationRate"
           type="number"
-          step="0.01"
+          step="0.001"
           isInvalid={!!errors.degradationRate}
           {...register("degradationRate", {
             valueAsNumber: true,


### PR DESCRIPTION
## Overview
In this PR, the degradation rate step has been updated from `0.01` to `0.001`. This allows for more control over this factor as an admin. THis has been updated in both the creating a commons form and editing a commons form.

## Screenshots (Optional)
Creating a commons:
<img width="1181" alt="Screenshot 2023-08-11 at 4 47 30 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/6acdb262-9da2-44dd-a91d-a2ca7d88a6f5">

Editing a commons:
<img width="1370" alt="Screenshot 2023-08-11 at 4 55 30 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/0d147cb4-a353-4fed-bf81-a0446c667ba4">


## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Create a new commons.
4. Test the degradation rate field to see that it has been updated to 0.001 intervals.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #28 
