### PR TITLE
FEATURE: Added back button to leaderboard page

### DIFF
--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -10,6 +10,8 @@ import { useBackend } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.png";
 
+import { useNavigate } from 'react-router-dom'
+import { Button } from 'react-bootstrap';
 
 export default function LeaderboardPage() {
 
@@ -46,6 +48,8 @@ export default function LeaderboardPage() {
     );
   // Stryker restore all 
 
+  const navigate = useNavigate();
+
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
@@ -58,6 +62,9 @@ export default function LeaderboardPage() {
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
                 </div>
+                <Button onClick={() => navigate(-1)} data-testid="LeaderboardPage-back-button" >
+                    Back
+                </Button>
         </BasicLayout>
     </div>
   )

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor, render } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -78,7 +78,26 @@ describe("LeaderboardPage tests", () => {
 
         });
         const leaderboard_main_div = screen.getByTestId("LeaderboardPage-main-div");
+        const leaderboard_back_button = screen.getByTestId("LeaderboardPage-back-button");
         expect(leaderboard_main_div).toHaveAttribute("style","background-size: cover; background-image: url(PlayPageBackground.png);");
+        expect(leaderboard_back_button).toBeInTheDocument();
+    });
+
+    test("that navigate(-1) is called when Back is clicked", async () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        await screen.findByTestId("LeaderboardPage-back-button");
+        const cancelButton = screen.getByTestId("LeaderboardPage-back-button");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(-1));
 
     });
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, a back button is added to the leaderboard page, which navigates to whichever page the user was previously on.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![chrome_QGgjAK9MNA](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/831c1b5f-29ea-454a-89d5-dea1a57bb2a9)

## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
- Is the positioning correct?

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #12
