### PR TITLE
Jobs Buttons Displays Relevant Text

### DIFF
--- a/frontend/src/main/components/Jobs/InstructorReportForm.js
+++ b/frontend/src/main/components/Jobs/InstructorReportForm.js
@@ -10,7 +10,7 @@ function InstructorReportForm( {submitAction} ) {
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       <p>Click this button to generate an instructor report!</p>
-      <Button type="submit" data-testid="InstructorReport-Submit-Button">Submit</Button>
+      <Button type="submit" data-testid="InstructorReport-Submit-Button">Generate</Button>
     </Form>
   );
 }

--- a/frontend/src/main/components/Jobs/InstructorReportSpecificCommonsForm.js
+++ b/frontend/src/main/components/Jobs/InstructorReportSpecificCommonsForm.js
@@ -46,7 +46,7 @@ function InstructorReportSpecificCommonsForm({  submitAction }) {
     <Form onSubmit={handleSubmit(onSubmit)}>
       <CommonsSelect commons={commons} selectedCommons={selectedCommons} handleCommonsSelection={handleCommonsSelection} testid={testid} />
       <p>Click this button to generate an instructor report for the selected commons.</p>
-      <Button type="submit" data-testid="InstructorReportSpecificCommonsForm-Submit-Button">Submit</Button>
+      <Button type="submit" data-testid="InstructorReportSpecificCommonsForm-Submit-Button">Generate</Button>
     </Form>
   );
 }

--- a/frontend/src/main/components/Jobs/MilkCowsJobForm.js
+++ b/frontend/src/main/components/Jobs/MilkCowsJobForm.js
@@ -13,7 +13,7 @@ function MilkTheCowsForm( {submitAction} ) {
     return (
       <Form onSubmit={handleSubmit(submitAction)}>
         <p>Click this button to milk the cows across all commons!</p>
-        <Button type="submit" data-testid="MilkTheCowsForm-Submit-Button">Update</Button>
+        <Button type="submit" data-testid="MilkTheCowsForm-Submit-Button">Milk!</Button>
     </Form>
     );
   }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the buttons for running jobs on the admin page have been updated to display text relevant to the job. This way, the buttons do not all say `Submit`, which can confuse some users. 

## Screenshots (Optional)
<img width="1322" alt="Screenshot 2023-08-11 at 5 07 54 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/d3a64bec-bd12-42c6-8f18-d4a34f57189e">
<img width="1319" alt="Screenshot 2023-08-11 at 5 07 58 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/1a5c6905-8374-4a37-b548-3ecfa9806875">


## Feedback Request (Optional)
If you have another idea of what these buttons should say, please let me know! I think anything besides "Submit" would be better.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #26 
