### PR TITLE
FEATURE: Add scheduled stat tracking for Commons

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -68,7 +68,6 @@ jobs:
             xargs printf '%s,' |                                    # convert to comma separated list
             sed 's/.$//' |                                          # remove trailing comma
             xargs -r npx stryker run --mutate                       # run stryker on changed files
-
         working-directory: ./frontend
 
       - name: Set path for github pages deploy when there is a PR num

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import OurTable, {ButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
-import { useNavigate } from "react-router-dom";
+import { useNavigate, } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
 export default function CommonsTable({ commons, currentUser }) {
@@ -24,8 +24,16 @@ export default function CommonsTable({ commons, currentUser }) {
     }
 
     const leaderboardCallback = (cell) => {
-        navigate(`/leaderboard/${cell.row.values["commons.id"]}`)
+        const route = `/leaderboard/${cell.row.values["commons.id"]}`
+        navigate(route)
     }
+
+    // Stryker disable all:difficult to test window.location.href
+    const statsCallback = (cell) => {
+        const route = `/api/commonstats/download?commonsId=${cell.row.values["commons.id"]}`
+        window.location.href=route;
+    }
+    // Stryker restore all
 
     const columns = [
         {
@@ -82,12 +90,10 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columnsIfAdmin = [
         ...columns,
-        ButtonColumn("Edit",
-"primary", editCallback, testid),
-        ButtonColumn("Delete",
-"danger", deleteCallback, testid),
-        ButtonColumn("Leaderboard",
-"secondary", leaderboardCallback, testid)
+        ButtonColumn("Edit", "primary", editCallback, testid),
+        ButtonColumn("Delete", "danger", deleteCallback, testid),
+        ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid),
+        ButtonColumn("Stats CSV", "success", statsCallback, testid),
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -1,5 +1,5 @@
 import React from "react";
-import OurTable, {ButtonColumn} from "main/components/OurTable";
+import OurTable, {ButtonColumn, HrefButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
 import { useNavigate, } from "react-router-dom";
@@ -27,13 +27,6 @@ export default function CommonsTable({ commons, currentUser }) {
         const route = `/leaderboard/${cell.row.values["commons.id"]}`
         navigate(route)
     }
-
-    // Stryker disable all:difficult to test window.location.href
-    const statsCallback = (cell) => {
-        const route = `/api/commonstats/download?commonsId=${cell.row.values["commons.id"]}`
-        window.location.href=route;
-    }
-    // Stryker restore all
 
     const columns = [
         {
@@ -93,7 +86,7 @@ export default function CommonsTable({ commons, currentUser }) {
         ButtonColumn("Edit", "primary", editCallback, testid),
         ButtonColumn("Delete", "danger", deleteCallback, testid),
         ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid),
-        ButtonColumn("Stats CSV", "success", statsCallback, testid),
+        HrefButtonColumn("Stats CSV", "success", `/api/commonstats/download?commonsId=`, testid),
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -116,6 +116,23 @@ export function ButtonColumn(label, variant, callback, testid) {
   return column;
 }
 
+export function HrefButtonColumn(label, variant, href, testid) {
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => (
+      <Button
+        variant={variant}
+        href={`${href}${cell.row.values["commons.id"]}`}
+        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+      >
+        {label}
+      </Button>
+    )
+  }
+  return column;
+}
+
 export function PlaintextColumn(label, getText) {
   const column = {
     Header: label,

--- a/frontend/src/main/pages/AdminListCommonPage.js
+++ b/frontend/src/main/pages/AdminListCommonPage.js
@@ -3,6 +3,7 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CommonsTable from 'main/components/Commons/CommonsTable';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button, Row, Col } from "react-bootstrap";
 
 export default function AdminListCommonsPage()
 {
@@ -20,7 +21,16 @@ export default function AdminListCommonsPage()
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>List Commons</h1>
+        <Row  className="pt-5">
+          <Col>
+            <h2>Commons</h2>
+          </Col>
+          <Col>
+            <Button href='/api/commonstats/downloadAll'>
+              Download All Stats
+            </Button>
+          </Col>
+        </Row>
         <CommonsTable commons={commons} currentUser={currentUser} />
       </div>
     </BasicLayout>

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -100,6 +100,8 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`)).toHaveClass("btn-primary");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`)).toHaveClass("btn-secondary");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Stats CSV-button`)).toHaveClass("btn-success");
+
   });
 
   test("the correct parameters are passed to useBackendMutation when Delete is clicked", async () => {

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -190,4 +190,25 @@ describe("AdminListCommonPage tests", () => {
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/leaderboard/1'));
     })
+
+    test("correct href for stats csv button as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
+      
+        const statsCSVButton = screen.getByTestId(`${testId}-cell-row-0-col-Stats CSV-button`);
+        expect(statsCSVButton).toHaveAttribute("href", "/api/commonstats/download?commonsId=1");
+
+    })
 });

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import {spyOn} from "jest-mock";
 
 import AdminListCommonPage from "main/pages/AdminListCommonPage";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
@@ -90,6 +91,7 @@ describe("AdminListCommonPage tests", () => {
         expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
         expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.id`)).toHaveTextContent("2");
         expect(screen.getByTestId(`${testId}-cell-row-2-col-commons.id`)).toHaveTextContent("3");
+        expect(screen.getByText(`Download All Stats`)).toBeInTheDocument();
     });
 
     test("renders empty table when backend unavailable, user only", async () => {
@@ -112,6 +114,7 @@ describe("AdminListCommonPage tests", () => {
         restoreConsole();
 
         expect(screen.queryByTestId(`${testId}-cell-row-0-col-commons.id`)).not.toBeInTheDocument();
+        expect(screen.getByText(`Download All Stats`)).toBeInTheDocument();
     });
 
     test("what happens when you click delete, admin", async () => {

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -4,7 +4,6 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import {spyOn} from "jest-mock";
 
 import AdminListCommonPage from "main/pages/AdminListCommonPage";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsController.java
@@ -1,0 +1,75 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.helpers.CommonStatsCSVHelper;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "CommonStats")
+@RequestMapping("/api/commonstats")
+@RestController
+public class CommonStatsController {
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    CommonStatsRepository commonStatsRepository;
+
+    @Operation(summary = "Get all common stats")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("")
+    public Iterable<CommonStats> allCommonStats() {
+        return commonStatsRepository.findAll();
+    }
+
+    @Operation(summary = "Get all stats for a commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/commons")
+    public Iterable<CommonStats> allCommonStatsForCommons(
+            @Parameter(name = "commonsId") @RequestParam Long commonsId) {
+        return commonStatsRepository.findAllByCommonsId(commonsId);
+    }
+
+    @Operation(summary = "Get all stats for a commons as csv")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping(value = "/download")
+    public ResponseEntity<Resource> getCSV(
+            @Parameter(name = "commonsId") @RequestParam Long commonsId) throws IOException {
+
+        Iterable<CommonStats> commonStats = commonStatsRepository.findAllByCommonsId(commonsId);
+                
+        String filename = String.format("stats%05d.csv",commonsId);
+
+        ByteArrayInputStream bais = CommonStatsCSVHelper.toCSV(commonStats);
+        InputStreamResource isr = new InputStreamResource(bais);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
+                .contentType(MediaType.parseMediaType("application/csv")).body(isr);
+    }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsController.java
@@ -71,5 +71,22 @@ public class CommonStatsController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
                 .contentType(MediaType.parseMediaType("application/csv")).body(isr);
     }
+
+    @Operation(summary = "Get all stats for all commons as csv")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping(value = "/downloadAll")
+    public ResponseEntity<Resource> getAllCSV() throws IOException {
+
+        Iterable<CommonStats> commonStats = commonStatsRepository.findAll();
+                
+        String filename = String.format("CommonStats.csv");
+
+        ByteArrayInputStream bais = CommonStatsCSVHelper.toCSV(commonStats);
+        InputStreamResource isr = new InputStreamResource(bais);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
+                .contentType(MediaType.parseMediaType("application/csv")).body(isr);
+    }
     
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -27,6 +27,8 @@ import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.RecordCommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.RecordCommonStatsJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
@@ -59,6 +61,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+    @Autowired
+    RecordCommonStatsJobFactory recordCommonStatsJobFactory;
 
     @Operation(summary = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -141,5 +146,15 @@ public class JobsController extends ApiController {
 
         InstructorReportJobSingleCommons instructorReportJobSingleCommons = (InstructorReportJobSingleCommons) instructorReportJobSingleCommonsFactory.create(commonsId);
         return jobService.runAsJob(instructorReportJobSingleCommons);
+    }
+
+    @Operation(summary = "Launch Job to Record the Stats of all Commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/recordcommonstats")
+    public Job recordCommonStats(
+    ) { 
+
+        RecordCommonStatsJob recordCommonStatsJob = (RecordCommonStatsJob) recordCommonStatsJobFactory.create();
+        return jobService.runAsJob(recordCommonStatsJob);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonStats.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonStats.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.util.Date;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "commonstats")
+public class CommonStats {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private long commonsId;
+    private int numCows;
+    private double avgHealth;
+    
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "create_date")
+    private Date createDate;
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -58,7 +58,8 @@ public class UserCommons {
     public void setId(UserCommonsKey id) {
         this.id = id;
     }
-     public UserCommonsKey getId() {
+    
+    public UserCommonsKey getId() {
         return this.id;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+
+/*
+ * This code is based on 
+ * <a href="https://bezkoder.com/spring-boot-download-csv-file/">https://bezkoder.com/spring-boot-download-csv-file/</a>
+ * and provides a way to serve up a CSV file containing information associated
+ * with an instructor report.
+ */
+
+public class CommonStatsCSVHelper {
+
+  private CommonStatsCSVHelper() {}
+
+  /**
+   * This method is a hack to avoid a jacoco issue; it isn't possible to 
+   * exclude an individual method call from jacoco coverage, but we can
+   * exclude the entire method.  
+   * @param out
+   */
+
+  public static void flush_and_close_noPitest(ByteArrayOutputStream out, CSVPrinter csvPrinter) throws IOException {
+    csvPrinter.flush();
+    csvPrinter.close();
+    out.flush();
+    out.close();
+  }
+  
+  public static ByteArrayInputStream toCSV(Iterable<CommonStats> stats) throws IOException {
+    final CSVFormat format = CSVFormat.DEFAULT;
+
+    List<String> headers = Arrays.asList(
+        "id",
+        "commonsId",
+        "numCows",
+        "avgHealth",
+        "createDate");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format);
+
+    csvPrinter.printRecord(headers);
+
+    for (CommonStats line : stats) {
+      List<String> data = Arrays.asList(
+          String.valueOf(line.getId()),
+          String.valueOf(line.getCommonsId()),
+          String.valueOf(line.getNumCows()),
+          String.valueOf(line.getAvgHealth()),
+          String.valueOf(line.getCreateDate()));
+      csvPrinter.printRecord(data);
+    }
+
+    flush_and_close_noPitest(out, csvPrinter);
+    return new ByteArrayInputStream(out.toByteArray());
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -22,7 +22,7 @@ public class CommonStatsCSVHelper {
   private CommonStatsCSVHelper() {}
 
   /**
-   * This method is a hack to avoid a jacoco issue; it isn't possible to 
+   * This method is a hack to avoid a pitest issue; it isn't possible to 
    * exclude an individual method call from jacoco coverage, but we can
    * exclude the entire method.  
    * @param out

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -24,7 +24,7 @@ public class CommonStatsCSVHelper {
   /**
    * This method is a hack to avoid a pitest issue; it isn't possible to 
    * exclude an individual method call from jacoco coverage, but we can
-   * exclude the entire method.  
+   * exclude the entire method by name in the pom.xml
    * @param out
    */
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -10,8 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
-//compute the stats for all games in progress and create one new row in the CommonsStats table for each commons. 
-//It will use the Average Cow Health Service to compute the cowhealth for each commons.
+/** This job computes the stats for all games in progress and creates one new row in the CommonsStats table for each commons.   It uses the Average Cow Health Service to compute the cowhealth for each commons.
+*/
 
 @AllArgsConstructor
 public class RecordCommonStatsJob implements JobContextConsumer {

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -11,7 +11,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
-//compute the stats for all games in progress and create one new row in the CommonsStats table for each commons. It will use the Average Cow Health Service to compute the cowhealth for each commons.
+//compute the stats for all games in progress and create one new row in the CommonsStats table for each commons. 
+//It will use the Average Cow Health Service to compute the cowhealth for each commons.
+
 @AllArgsConstructor
 public class RecordCommonStatsJob implements JobContextConsumer {
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -16,9 +16,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RecordCommonStatsJob implements JobContextConsumer {
 
-
+    @Getter
     private CommonStatsService commonStatsService;
 
+    @Getter
     private CommonsRepository commonsRepository;
 
     @Override

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.CommonStatsService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
-import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,13 +16,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RecordCommonStatsJob implements JobContextConsumer {
 
-    @Getter
-    private AverageCowHealthService averageCowHealthService;
 
-    @Getter
     private CommonStatsService commonStatsService;
 
-    @Getter
     private CommonsRepository commonsRepository;
 
     @Override

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.CommonStatsService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+//compute the stats for all games in progress and create one new row in the CommonsStats table for each commons. It will use the Average Cow Health Service to compute the cowhealth for each commons.
+@AllArgsConstructor
+public class RecordCommonStatsJob implements JobContextConsumer {
+
+    @Getter
+    private AverageCowHealthService averageCowHealthService;
+
+    @Getter
+    private CommonStatsService commonStatsService;
+
+    @Getter
+    private CommonsRepository commonsRepository;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Starting record common stats job...");
+        Iterable<Commons> allCommons = commonsRepository.findAll();
+
+        for (Commons commons : allCommons) {
+            ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
+            CommonStats commonStats = commonStatsService.createCommonStats(commons.getId());
+            ctx.log(String.format("CommonStats %d for commons id=%d (%s) finished.", commonStats.getId(), commons.getId(),
+                    commons.getName()));
+        }
+        ctx.log("Record common stats job done!");
+    }
+}
+

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactory.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.CommonStatsService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+
+@Service
+public class RecordCommonStatsJobFactory {
+    
+    @Autowired
+    private CommonsRepository commonsRepository;
+
+    @Autowired
+    private CommonStatsService commonStatsService;
+
+    public JobContextConsumer create() {
+        return new RecordCommonStatsJob(
+            commonStatsService,
+            commonsRepository);
+    }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -34,7 +34,7 @@ public class ScheduledJobs {
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
     
-    @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "America/Los_Angeles")
+    @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "${spring.jackson.time-zone}")
     public void runUpdateCowHealthJobBasedOnCron() {
        log.info("runUpdateCowHealthJobBasedOnCron: running");
 
@@ -44,7 +44,7 @@ public class ScheduledJobs {
       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
    }
 
-    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "America/Los_Angeles")
+    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "${spring.jackson.time-zone}")
     public void runMilkTheCowsJobBasedOnCron() {
        log.info("runMilkTheCowsJobBasedOnCron: running");
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -25,32 +25,45 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ScheduledJobs {
 
-    @Autowired
-    private JobService jobService;
+   @Autowired
+   private JobService jobService;
 
-    @Autowired
-    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+   @Autowired
+   UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
-    @Autowired
-    MilkTheCowsJobFactory milkTheCowsJobFactory;
-    
-    @Scheduled(cron = "${app.updateCowHealth.cron}")
-    public void runUpdateCowHealthJobBasedOnCron() {
-       log.info("runUpdateCowHealthJobBasedOnCron: running");
+   @Autowired
+   MilkTheCowsJobFactory milkTheCowsJobFactory;
 
-       JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
-       jobService.runAsJob(updateCowHealthJob);
-    
-       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
-    }
+   @Autowired
+   RecordCommonStatsJobFactory recordCommonStatsJobFactory;
+   
+   @Scheduled(cron = "${app.updateCowHealth.cron}")
+   public void runUpdateCowHealthJobBasedOnCron() {
+      log.info("runUpdateCowHealthJobBasedOnCron: running");
 
-    @Scheduled(cron = "${app.milkTheCows.cron}")
-    public void runMilkTheCowsJobBasedOnCron() {
-       log.info("runMilkTheCowsJobBasedOnCron: running");
+      JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
+      jobService.runAsJob(updateCowHealthJob);
+   
+      log.info("runUpdateCowHealthJobBasedOnCron: launched job");
+   }
 
-       JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
-       jobService.runAsJob(milkTheCowsJob);
-    
-       log.info("runMilkTheCowsJobBasedOnCron: launched job");
-    }
+   @Scheduled(cron = "${app.milkTheCows.cron}")
+   public void runMilkTheCowsJobBasedOnCron() {
+      log.info("runMilkTheCowsJobBasedOnCron: running");
+
+      JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
+      jobService.runAsJob(milkTheCowsJob);
+   
+      log.info("runMilkTheCowsJobBasedOnCron: launched job");
+   }
+
+   @Scheduled(cron = "${app.recordCommonStats.cron}")
+   public void runRecordCommonStatsJobBasedOnCron() {
+      log.info("runRecordCommonStatsJobBasedOnCron: running");
+
+      JobContextConsumer recordCommonStatsJob = recordCommonStatsJobFactory.create();
+      jobService.runAsJob(recordCommonStatsJob);
+
+      log.info("runRecordCommonStatsJobBasedOnCron: launched job");
+   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -27,11 +27,7 @@ public class ScheduledJobs {
 
    @Autowired
    private JobService jobService;
-   @Autowired
-   private JobService jobService;
 
-   @Autowired
-   UpdateCowHealthJobFactory updateCowHealthJobFactory;
    @Autowired
    UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
@@ -50,11 +46,6 @@ public class ScheduledJobs {
    
       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
    }
-      JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
-      jobService.runAsJob(updateCowHealthJob);
-   
-      log.info("runUpdateCowHealthJobBasedOnCron: launched job");
-   }
 
    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "${spring.jackson.time-zone}")
    public void runMilkTheCowsJobBasedOnCron() {
@@ -66,22 +57,7 @@ public class ScheduledJobs {
       log.info("runMilkTheCowsJobBasedOnCron: launched job");
    }
 
-   @Scheduled(cron = "${app.recordCommonStats.cron}")
-   public void runRecordCommonStatsJobBasedOnCron() {
-      log.info("runRecordCommonStatsJobBasedOnCron: running");
-
-      JobContextConsumer recordCommonStatsJob = recordCommonStatsJobFactory.create();
-      jobService.runAsJob(recordCommonStatsJob);
-
-      log.info("runRecordCommonStatsJobBasedOnCron: launched job");
-   }
-      JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
-      jobService.runAsJob(milkTheCowsJob);
-   
-      log.info("runMilkTheCowsJobBasedOnCron: launched job");
-   }
-
-   @Scheduled(cron = "${app.recordCommonStats.cron}")
+   @Scheduled(cron = "${app.recordCommonStats.cron}", zone = "${spring.jackson.time-zone}")
    public void runRecordCommonStatsJobBasedOnCron() {
       log.info("runRecordCommonStatsJobBasedOnCron: running");
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -31,15 +31,12 @@ public class ScheduledJobs {
    @Autowired
    UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
-   @Autowired
-   MilkTheCowsJobFactory milkTheCowsJobFactory;
-
-   @Autowired
-   RecordCommonStatsJobFactory recordCommonStatsJobFactory;
-   
-   @Scheduled(cron = "${app.updateCowHealth.cron}")
-   public void runUpdateCowHealthJobBasedOnCron() {
-      log.info("runUpdateCowHealthJobBasedOnCron: running");
+    @Autowired
+    MilkTheCowsJobFactory milkTheCowsJobFactory;
+    
+    @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "America/Los_Angeles")
+    public void runUpdateCowHealthJobBasedOnCron() {
+       log.info("runUpdateCowHealthJobBasedOnCron: running");
 
       JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
       jobService.runAsJob(updateCowHealthJob);
@@ -47,9 +44,9 @@ public class ScheduledJobs {
       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
    }
 
-   @Scheduled(cron = "${app.milkTheCows.cron}")
-   public void runMilkTheCowsJobBasedOnCron() {
-      log.info("runMilkTheCowsJobBasedOnCron: running");
+    @Scheduled(cron = "${app.milkTheCows.cron}")
+    public void runMilkTheCowsJobBasedOnCron() {
+       log.info("runMilkTheCowsJobBasedOnCron: running", zone = "America/Los_Angeles");
 
       JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
       jobService.runAsJob(milkTheCowsJob);

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -27,27 +27,54 @@ public class ScheduledJobs {
 
    @Autowired
    private JobService jobService;
+   @Autowired
+   private JobService jobService;
 
    @Autowired
    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+   @Autowired
+   UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
-    @Autowired
-    MilkTheCowsJobFactory milkTheCowsJobFactory;
-    
-    @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "${spring.jackson.time-zone}")
-    public void runUpdateCowHealthJobBasedOnCron() {
-       log.info("runUpdateCowHealthJobBasedOnCron: running");
+   @Autowired
+   MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+   @Autowired
+   RecordCommonStatsJobFactory recordCommonStatsJobFactory;
+   
+   @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "${spring.jackson.time-zone}")
+   public void runUpdateCowHealthJobBasedOnCron() {
+      log.info("runUpdateCowHealthJobBasedOnCron: running");
 
       JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
       jobService.runAsJob(updateCowHealthJob);
    
       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
    }
+      JobContextConsumer updateCowHealthJob = updateCowHealthJobFactory.create();
+      jobService.runAsJob(updateCowHealthJob);
+   
+      log.info("runUpdateCowHealthJobBasedOnCron: launched job");
+   }
 
-    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "${spring.jackson.time-zone}")
-    public void runMilkTheCowsJobBasedOnCron() {
-       log.info("runMilkTheCowsJobBasedOnCron: running");
+   @Scheduled(cron = "${app.milkTheCows.cron}", zone = "${spring.jackson.time-zone}")
+   public void runMilkTheCowsJobBasedOnCron() {
+      log.info("runMilkTheCowsJobBasedOnCron: running");
 
+      JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
+      jobService.runAsJob(milkTheCowsJob);
+   
+      log.info("runMilkTheCowsJobBasedOnCron: launched job");
+   }
+
+   @Scheduled(cron = "${app.recordCommonStats.cron}")
+   public void runRecordCommonStatsJobBasedOnCron() {
+      log.info("runRecordCommonStatsJobBasedOnCron: running");
+
+      JobContextConsumer recordCommonStatsJob = recordCommonStatsJobFactory.create();
+      jobService.runAsJob(recordCommonStatsJob);
+
+      log.info("runRecordCommonStatsJobBasedOnCron: launched job");
+   }
       JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
       jobService.runAsJob(milkTheCowsJob);
    

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -44,9 +44,9 @@ public class ScheduledJobs {
       log.info("runUpdateCowHealthJobBasedOnCron: launched job");
    }
 
-    @Scheduled(cron = "${app.milkTheCows.cron}")
+    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "America/Los_Angeles")
     public void runMilkTheCowsJobBasedOnCron() {
-       log.info("runMilkTheCowsJobBasedOnCron: running", zone = "America/Los_Angeles");
+       log.info("runMilkTheCowsJobBasedOnCron: running");
 
       JobContextConsumer milkTheCowsJob = milkTheCowsJobFactory.create();
       jobService.runAsJob(milkTheCowsJob);

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import org.springframework.data.domain.Sort;
+
+@Repository
+public interface CommonStatsRepository extends CrudRepository<CommonStats, Long> {
+    Iterable<CommonStats> findAllByCommonsId(Long commonsId);
+    Iterable<CommonStats> findAll(Sort sort);
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+@Service("AverageCowHealthService")
+public class AverageCowHealthService {
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    public double getAverageCowHealth(Long commonsId) {
+        commonsRepository.findById(commonsId).orElseThrow(() -> new RuntimeException(String.format("Commons with id %d not found", commonsId)));
+
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
+
+        double totalHealth = 0;
+        int numCows = 0;
+
+        for (UserCommons userCommons : allUserCommons) {
+            totalHealth += userCommons.getCowHealth() * userCommons.getNumOfCows();
+            numCows += userCommons.getNumOfCows();
+        }
+
+        return totalHealth / numCows;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -16,19 +16,33 @@ public class AverageCowHealthService {
     @Autowired
     UserCommonsRepository userCommonsRepository;
 
+    public int getTotalNumCows(Long commonsId) {
+        commonsRepository.findById(commonsId).orElseThrow(() -> new IllegalArgumentException(String.format("Commons with id %d not found", commonsId)));
+
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
+
+        int totalNumCows = 0;
+
+        for (UserCommons userCommons : allUserCommons) {
+            totalNumCows += userCommons.getNumOfCows();
+        }
+
+        return totalNumCows;
+    }
+
     public double getAverageCowHealth(Long commonsId) {
-        commonsRepository.findById(commonsId).orElseThrow(() -> new RuntimeException(String.format("Commons with id %d not found", commonsId)));
+        commonsRepository.findById(commonsId).orElseThrow(() -> new IllegalArgumentException(String.format("Commons with id %d not found", commonsId)));
 
         Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
 
         double totalHealth = 0;
-        int numCows = 0;
 
         for (UserCommons userCommons : allUserCommons) {
             totalHealth += userCommons.getCowHealth() * userCommons.getNumOfCows();
-            numCows += userCommons.getNumOfCows();
         }
 
-        return totalHealth / numCows;
+        return totalHealth / getTotalNumCows(commonsId);
     }
+
+    
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
@@ -3,13 +3,10 @@ package edu.ucsb.cs156.happiercows.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonStats;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
 
 @Service("CommonStatsService")
 public class CommonStatsService {
@@ -24,17 +21,12 @@ public class CommonStatsService {
     UserCommonsRepository userCommonsRepository;
 
     @Autowired
-    AverageCowHealthService averageCowHealthService;
+    private AverageCowHealthService averageCowHealthService;
 
     public CommonStats createCommonStats(Long commonsId) {
-        CommonStats stats = createAndSaveCommonStatsHeader(commonsId);
-        
-        return stats;
-    }
 
-    public CommonStats createAndSaveCommonStatsHeader(Long commonsId) {
         commonsRepository.findById(commonsId)
-            .orElseThrow(() -> new RuntimeException(String.format("Commons with id %d not found", commonsId)));
+            .orElseThrow(() -> new IllegalArgumentException(String.format("Commons with id %d not found", commonsId)));
         
         double avgHealth = averageCowHealthService.getAverageCowHealth(commonsId);
         int totalNumCows = averageCowHealthService.getTotalNumCows(commonsId);
@@ -44,6 +36,13 @@ public class CommonStatsService {
                 .numCows(totalNumCows)
                 .avgHealth(avgHealth)
                 .build();
+
+        return stats;
+    }
+
+    public CommonStats createAndSaveCommonStats(Long commonsId) {
+        
+        CommonStats stats = createCommonStats(commonsId);
 
         commonStatsRepository.save(stats);
         return stats;

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+
+@Service("CommonStatsService")
+public class CommonStatsService {
+
+    @Autowired
+    CommonStatsRepository commonStatsRepository;
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    AverageCowHealthService averageCowHealthService;
+
+    public CommonStats createCommonStats(Long commonsId) {
+        CommonStats stats = createAndSaveCommonStatsHeader(commonsId);
+        
+        return stats;
+    }
+
+    public CommonStats createAndSaveCommonStatsHeader(Long commonsId) {
+        commonsRepository.findById(commonsId)
+            .orElseThrow(() -> new RuntimeException(String.format("Commons with id %d not found", commonsId)));
+        
+        double avgHealth = averageCowHealthService.getAverageCowHealth(commonsId);
+        int totalNumCows = averageCowHealthService.getTotalNumCows(commonsId);
+
+        CommonStats stats = CommonStats.builder()
+                .commonsId(commonsId)
+                .numCows(totalNumCows)
+                .avgHealth(avgHealth)
+                .build();
+
+        commonStatsRepository.save(stats);
+        return stats;
+    }
+
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -13,3 +13,4 @@ spring.datasource.initialization-mode=always
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 */7 * * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 */13 * * * *}}
+app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0/6 * * *}}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -13,4 +13,4 @@ spring.datasource.initialization-mode=always
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 */7 * * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 */13 * * * *}}
-app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0/6 * * *}}
+app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 */6 * * * *}}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -13,4 +13,4 @@ spring.datasource.initialization-mode=always
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 */7 * * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 */13 * * * *}}
-app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 */6 * * * *}}
+app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0/6 * * *}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,3 +37,4 @@ app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,4 +37,3 @@ app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
 spring.jackson.time-zone=America/Los_Angeles
-

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,4 +35,4 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 0 0,12 * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
-
+app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0/6 * * *}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,4 +35,4 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 0 0,12 * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
-app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0/6 * * *}}
+app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,5 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 0 0,12 * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
 app.recordCommonStats.cron=${RECORD_COMMON_STATS_CRON:${env.RECORD_COMMON_STATS_CRON:0 0 0,6,12,18 * * *}}
+spring.jackson.time-zone=America/Los_Angeles
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
@@ -149,4 +149,25 @@ public class CommonStatsControllerTests extends ControllerTestCase {
             assertEquals(expected, responseString);
     }
 
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_get_all_csv() throws Exception {
+            when(commonStatsRepository.findAll()).thenReturn(List.of(expectedStats1, expectedStats2));
+            
+            MvcResult response = mockMvc.perform(get("/api/commonstats/downloadAll")).andDo(print())
+                            .andExpect(status().isOk()).andReturn();
+
+            verify(commonStatsRepository, times(1)).findAll();
+            String responseString = response.getResponse().getContentAsString();
+
+            assertEquals("application/csv", response.getResponse().getContentType());
+
+            String expected = 
+                    "id,commonsId,numCows,avgHealth,createDate\r\n" +
+                    "0,17,20,10.0,null\r\n" +
+                    "0,42,120,20.0,null\r\n";
+                                        
+            assertEquals(expected, responseString);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonStatsControllerTests.java
@@ -1,0 +1,152 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.Report;
+import edu.ucsb.cs156.happiercows.entities.ReportLine;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
+import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+import edu.ucsb.cs156.happiercows.services.CommonStatsService;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CommonStatsController.class)
+@Import(CommonStatsController.class)
+@AutoConfigureDataJpa
+public class CommonStatsControllerTests extends ControllerTestCase {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+        
+    @MockBean
+    UserRepository userRepository;
+  
+    @MockBean
+    CommonsRepository commonsRepository;
+  
+    @MockBean
+    UserCommonsRepository userCommonsRepository;   
+
+    @MockBean
+    CommonStatsRepository commonStatsRepository;    
+
+    @MockBean
+    AverageCowHealthService averageCowHealthService;
+
+
+    private Commons commons = Commons
+        .builder()
+        .id(17L)
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+        .showLeaderboard(true)
+        .carryingCapacity(100)
+        .degradationRate(0.01)
+        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .build();
+
+    CommonStats expectedStats1 = CommonStats
+        .builder()
+        .commonsId(17L)
+        .numCows(20)
+        .avgHealth(10)
+        .build();
+
+    CommonStats expectedStats2 = CommonStats
+        .builder()
+        .commonsId(42L)
+        .numCows(120)
+        .avgHealth(20)
+        .build();
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void get_all_common_stats() throws Exception {
+        Iterable<CommonStats> expectedStats = List.of(expectedStats1, expectedStats2);
+        when(commonStatsRepository.findAll()).thenReturn(expectedStats);
+
+        MvcResult response = mockMvc.perform(get("/api/commonstats")).andDo(print())
+        .andExpect(status().isOk()).andReturn();
+
+        verify(commonStatsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+                List<CommonStats> actualStats = objectMapper.readValue(responseString, new TypeReference<List<CommonStats>>() {
+                });
+                assertEquals(expectedStats, actualStats);
+
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void get_stats_by_commonsId() throws Exception {
+        Iterable<CommonStats> expectedStats = List.of(expectedStats1);
+        when(commonStatsRepository.findAllByCommonsId(17L)).thenReturn(expectedStats);
+
+        MvcResult response = mockMvc.perform(get("/api/commonstats/commons?commonsId=17")).andDo(print())
+        .andExpect(status().isOk()).andReturn();
+
+        verify(commonStatsRepository, times(1)).findAllByCommonsId(17L);
+
+        String responseString = response.getResponse().getContentAsString();
+                List<CommonStats> actualStats = objectMapper.readValue(responseString, new TypeReference<List<CommonStats>>() {
+                });
+                assertEquals(expectedStats, actualStats);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_get_csv() throws Exception {
+            when(commonStatsRepository.findAllByCommonsId(17L)).thenReturn(List.of(expectedStats1));
+            
+            MvcResult response = mockMvc.perform(get("/api/commonstats/download?commonsId=17")).andDo(print())
+                            .andExpect(status().isOk()).andReturn();
+
+            verify(commonStatsRepository, times(1)).findAllByCommonsId(eq(17L));
+            String responseString = response.getResponse().getContentAsString();
+
+            assertEquals("application/csv", response.getResponse().getContentType());
+
+            String expected = 
+                    "id,commonsId,numCows,avgHealth,createDate\r\n" +
+                    "0,17,20,10.0,null\r\n";
+                                        
+            assertEquals(expected, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -47,6 +47,8 @@ import edu.ucsb.cs156.happiercows.jobs.InstructorReportJobSingleCommonsFactory;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.RecordCommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.RecordCommonStatsJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -89,6 +91,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
         @MockBean
         InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+        @MockBean
+        RecordCommonStatsJobFactory recordCommonStatsJobFactory;
 
         @WithMockUser(roles = { "ADMIN" })
         @Test
@@ -306,6 +311,21 @@ public class JobsControllerTests extends ControllerTestCase {
                 MvcResult response = mockMvc
                                 .perform(post("/api/jobs/launch/instructorreportsinglecommons?commonsId=1")
                                                 .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_record_common_stats_job() throws Exception {
+                // act
+                MvcResult response = mockMvc.perform(post("/api/jobs/launch/recordcommonstats").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobFactoryTests.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.CommonStatsService;
+
+@RestClientTest(RecordCommonStatsJobFactory.class)
+@AutoConfigureDataJpa
+public class RecordCommonStatsJobFactoryTests {
+
+    @MockBean
+    CommonStatsService commonStatsService;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    RecordCommonStatsJobFactory RecordCommonStatsJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        RecordCommonStatsJob recordCommonStatsJob = (RecordCommonStatsJob) RecordCommonStatsJobFactory.create();
+
+        // Assert
+        assertEquals(commonsRepository,recordCommonStatsJob.getCommonsRepository());
+        assertEquals(commonStatsService,recordCommonStatsJob.getCommonStatsService());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
@@ -50,7 +50,7 @@ public class RecordCommonStatsJobTests {
 
         // Act
         RecordCommonStatsJob recordCommonStatsJob = 
-                new RecordCommonStatsJob(averageCowHealthService, commonStatsService, commonsRepository);
+                new RecordCommonStatsJob(commonStatsService, commonsRepository);
         recordCommonStatsJob.accept(ctx);
 
         // Assert
@@ -76,7 +76,7 @@ public class RecordCommonStatsJobTests {
 
         // Act
         RecordCommonStatsJob recordCommonStatsJob = 
-                new RecordCommonStatsJob(averageCowHealthService, commonStatsService, commonsRepository);
+                new RecordCommonStatsJob(commonStatsService, commonsRepository);
         recordCommonStatsJob.accept(ctx);
 
         // Assert

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
@@ -1,0 +1,92 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+import edu.ucsb.cs156.happiercows.services.CommonStatsService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class RecordCommonStatsJobTests {
+
+    @MockBean
+    AverageCowHealthService averageCowHealthService;
+
+    @MockBean
+    CommonStatsService commonStatsService;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Test
+    void test_log_output() throws Exception {
+
+        // Arrange
+
+        Commons commons= Commons.builder().id(17L).name("CS156").build();
+        CommonStats commonStats = CommonStats.builder().id(17L).build();
+        
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+      
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
+        when(commonStatsService.createCommonStats(17L)).thenReturn(commonStats);
+
+        // Act
+        RecordCommonStatsJob recordCommonStatsJob = 
+                new RecordCommonStatsJob(averageCowHealthService, commonStatsService, commonsRepository);
+        recordCommonStatsJob.accept(ctx);
+
+        // Assert
+
+        verify(commonsRepository).findAll();
+        verify(commonStatsService).createCommonStats(17L);
+        
+        String expected = """
+            Starting record common stats job...
+            Starting Commons id=17 (CS156)...
+            CommonStats 17 for commons id=17 (CS156) finished.
+            Record common stats job done!""";
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_no_commons() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+        when(commonsRepository.findAll()).thenReturn(new ArrayList<>());
+
+        // Act
+        RecordCommonStatsJob recordCommonStatsJob = 
+                new RecordCommonStatsJob(averageCowHealthService, commonStatsService, commonsRepository);
+        recordCommonStatsJob.accept(ctx);
+
+        // Assert
+
+        verify(commonsRepository).findAll();
+        
+        String expected = """
+            Starting record common stats job...
+            Record common stats job done!""";
+        assertEquals(expected, jobStarted.getLog());
+    }
+    
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -42,6 +43,9 @@ public class ScheduledJobsTests {
 
     @MockBean
     MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+    @MockBean
+    RecordCommonStatsJobFactory recordCommonStatsJobFactory;
 
     @Autowired
     private ScheduledJobs scheduledJobs;
@@ -90,6 +94,28 @@ public class ScheduledJobsTests {
 
         verify(jobService, times(1)).runAsJob(mockJob);
         verify(milkTheCowsJobFactory, times(1)).create();
+
+    }
+
+    @Test
+    void test_runRecordCommonStatsJobBasedOnCron() throws Exception {
+
+        // Arrange
+
+        Job job = Job.builder().build();
+        MockJobContextConsumer mockJob = new MockJobContextConsumer();
+
+       when(recordCommonStatsJobFactory.create()).thenReturn(mockJob);
+       when(jobService.runAsJob(any())).thenReturn(job);
+
+        // Act
+
+        scheduledJobs.runRecordCommonStatsJobBasedOnCron();
+
+        // Assert
+
+        verify(jobService, times(1)).runAsJob(mockJob);
+        verify(recordCommonStatsJobFactory, times(1)).create();
 
     }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -1,24 +1,11 @@
 package edu.ucsb.cs156.happiercows.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
-
-
-import javax.persistence.Column;
-import javax.persistence.Enumerated;
-import javax.persistence.TemporalType;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +16,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-
-import edu.ucsb.cs156.happiercows.ControllerTestCase;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.User;

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -94,45 +94,70 @@ public class AverageCowHealthServiceTests {
         .cowDeaths(6)
         .build();
 
+    private User user2 = User
+        .builder()
+        .id(43L)
+        .fullName("John Doe")
+        .email("jdoe@example.org")
+        .build();
+
+    UserCommons userCommons2 = UserCommons
+        .builder()
+        .user(user2)
+        .username("John Doe")
+        .commons(commons)
+        .totalWealth(300)
+        .numOfCows(100)
+        .cowHealth(22)
+        .cowsBought(20)
+        .cowsSold(12)
+        .cowDeaths(2)
+        .build();
+
+
     @BeforeEach
     void setup() {
-      userCommons1.setId(new UserCommonsKey(user1.getId(), commons.getId()));
+        userCommons1.setId(new UserCommonsKey(user1.getId(), commons.getId()));
+        userCommons2.setId(new UserCommonsKey(user2.getId(), commons.getId()));
     }
 
     @Test
     void test_getAverageCowHealthOneUser() {
-        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(Arrays.asList(userCommons1));
+        // arrange
 
-        assertEquals(10, averageCowHealthService.getAverageCowHealth(commons.getId()));
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId()))
+                .thenReturn(Arrays.asList(userCommons1));
+        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(20)));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
+
+        // act
+
+        double averageCowHealth = averageCowHealthService.getAverageCowHealth(17L);
+
+        // assert
+        assertEquals(10, averageCowHealth);
     }
 
     @Test
     void test_getAverageCowHealthMultipleUsers() {
+        // arrange
 
-        User user2 = User
-            .builder()
-            .id(43L)
-            .fullName("John Doe")
-            .email("jdoe@example.org")
-            .build();
-        UserCommons userCommons2 = UserCommons
-            .builder()
-            .user(user2)
-            .username("John Doe")
-            .commons(commons)
-            .totalWealth(300)
-            .numOfCows(100)
-            .cowHealth(22)
-            .cowsBought(20)
-            .cowsSold(12)
-            .cowDeaths(2)
-            .build();
-        userCommons2.setId(new UserCommonsKey(user2.getId(), commons.getId()));
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(userCommonsRepository.findByCommonsId(commons.getId()))
+                .thenReturn(Arrays.asList(userCommons1,userCommons2));
+        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(120)));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
+        when(userRepository.findById(43L)).thenReturn(Optional.of(user2));
 
-        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(Arrays.asList(userCommons1, userCommons2));
+        // act
 
-        assertEquals(20, averageCowHealthService.getAverageCowHealth(commons.getId()));
+        double averageCowHealth = averageCowHealthService.getAverageCowHealth(17L);
 
+        // assert
+        assertEquals(20, averageCowHealth);
     }
 
     @Test
@@ -141,6 +166,15 @@ public class AverageCowHealthServiceTests {
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             averageCowHealthService.getAverageCowHealth(1L);
+        });
+    }
+
+    @Test
+    void test_getTotalNumCowsThrowsException() {
+        when(userCommonsRepository.findByCommonsId(1L)).thenReturn(Arrays.asList());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            averageCowHealthService.getTotalNumCows(1L);
         });
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -1,0 +1,146 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+
+import javax.persistence.Column;
+import javax.persistence.Enumerated;
+import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.UserCommonsKey;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+@ExtendWith(SpringExtension.class)
+@Import(AverageCowHealthService.class)
+@ContextConfiguration
+public class AverageCowHealthServiceTests {
+    
+    @MockBean
+    UserRepository userRepository;
+  
+    @MockBean
+    CommonsRepository commonsRepository;
+  
+    @MockBean
+    UserCommonsRepository userCommonsRepository;    
+
+    @Autowired
+    AverageCowHealthService averageCowHealthService;
+
+    private Commons commons = Commons
+        .builder()
+        .id(17L)
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+        .showLeaderboard(true)
+        .carryingCapacity(100)
+        .degradationRate(0.01)
+        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .build();
+
+    private User user1 = User
+        .builder()
+        .id(42L)
+        .fullName("Chris Gaucho")
+        .email("cgaucho@example.org")
+        .build();
+
+    UserCommons userCommons1 = UserCommons
+        .builder()
+        .user(user1)
+        .username("Chris Gaucho")
+        .commons(commons)
+        .totalWealth(300)
+        .numOfCows(20)
+        .cowHealth(10)
+        .cowsBought(10)
+        .cowsSold(23)
+        .cowDeaths(6)
+        .build();
+
+    @BeforeEach
+    void setup() {
+      userCommons1.setId(new UserCommonsKey(user1.getId(), commons.getId()));
+    }
+
+    @Test
+    void test_getAverageCowHealthOneUser() {
+        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(Arrays.asList(userCommons1));
+
+        assertEquals(10, averageCowHealthService.getAverageCowHealth(commons.getId()));
+    }
+
+    @Test
+    void test_getAverageCowHealthMultipleUsers() {
+
+        User user2 = User
+            .builder()
+            .id(43L)
+            .fullName("John Doe")
+            .email("jdoe@example.org")
+            .build();
+        UserCommons userCommons2 = UserCommons
+            .builder()
+            .user(user2)
+            .username("John Doe")
+            .commons(commons)
+            .totalWealth(300)
+            .numOfCows(100)
+            .cowHealth(22)
+            .cowsBought(20)
+            .cowsSold(12)
+            .cowDeaths(2)
+            .build();
+        userCommons2.setId(new UserCommonsKey(user2.getId(), commons.getId()));
+
+        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(Arrays.asList(userCommons1, userCommons2));
+
+        assertEquals(20, averageCowHealthService.getAverageCowHealth(commons.getId()));
+
+    }
+
+    @Test
+    void test_getAverageCowHealthThrowsException() {
+        when(userCommonsRepository.findByCommonsId(1L)).thenReturn(Arrays.asList());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            averageCowHealthService.getAverageCowHealth(1L);
+        });
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/CommonStatsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/CommonStatsServiceTests.java
@@ -1,0 +1,123 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+@ExtendWith(SpringExtension.class)
+@Import(CommonStatsService.class)
+@ContextConfiguration
+public class CommonStatsServiceTests {
+    
+    @MockBean
+    UserRepository userRepository;
+  
+    @MockBean
+    CommonsRepository commonsRepository;
+  
+    @MockBean
+    UserCommonsRepository userCommonsRepository;   
+
+    @MockBean
+    CommonStatsRepository commonStatsRepository;    
+
+    @MockBean
+    AverageCowHealthService averageCowHealthService;
+
+    @Autowired
+    CommonStatsService commonStatsService;
+
+    private Commons commons = Commons
+        .builder()
+        .id(17L)
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+        .showLeaderboard(true)
+        .carryingCapacity(100)
+        .degradationRate(0.01)
+        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+        .build();
+
+    CommonStats expectedStats1 = CommonStats
+        .builder()
+        .commonsId(17L)
+        .numCows(20)
+        .avgHealth(10)
+        .build();
+
+    CommonStats expectedStats2 = CommonStats
+        .builder()
+        .commonsId(17L)
+        .numCows(120)
+        .avgHealth(20)
+        .build();
+
+
+    @Test
+    void test_saveStatsOneUser() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(averageCowHealthService.getAverageCowHealth(17L)).thenReturn(10.0);
+        when(averageCowHealthService.getTotalNumCows(17L)).thenReturn(20);
+
+        // act
+
+        CommonStats stats = commonStatsService.createAndSaveCommonStats(17L);
+
+        // assert
+        verify(commonStatsRepository).save(eq(expectedStats1));
+        assertEquals(expectedStats1, stats);
+    }
+
+    @Test
+    void test_saveStatsMultipleUsers() {
+        // arrange
+
+        when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
+        when(averageCowHealthService.getAverageCowHealth(17L)).thenReturn(20.0);
+        when(averageCowHealthService.getTotalNumCows(17L)).thenReturn(120);
+
+        // act
+
+        CommonStats stats = commonStatsService.createAndSaveCommonStats(17L);
+
+        // assert
+        verify(commonStatsRepository).save(eq(expectedStats2));
+        assertEquals(expectedStats2, stats);
+    }
+
+    @Test
+    void test_getAverageCowHealthThrowsException() {
+        when(commonsRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            commonStatsService.createAndSaveCommonStats(1L);
+        });
+    }
+}


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, a job is added to periodically track commons statistics, including average cow health and the total number of cows. This job is set to run every 6 hours and results are saved to a repository on the backend. The Admin/ListCommons page has buttons to download the statistics for each commons as a .csv file.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![chrome_9LvzsK1haw](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/66a2af1d-fc01-4dfc-8834-3505c5dd7019)

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- Add more stats to log

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Start a job through swagger
4. Go to /admin/listcommons
5. Test the download

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #5
