### PR TITLE
fix: add backend checks for newCowHealth

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
@@ -31,6 +31,11 @@ public class SetCowHealthJob implements JobContextConsumer {
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Setting cow health...");
 
+        if (newCowHealth > 100 || newCowHealth < 0) {
+            ctx.log("Cow health must be between 0 and 100");
+            return;
+        }
+
         Optional<Commons> commons = commonsRepository.findById(commonsID);
 
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -138,4 +138,91 @@ public class SetCowHealthJobTests {
         assertEquals(expected, jobStarted.getLog());
         userCommonsList.forEach(userCommons -> assertEquals(newUserCommons.getCowHealth(), userCommons.getCowHealth()));
     }
+
+    @Test
+    void test_invalid_health_smaller_than_0() throws Exception {
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+
+        // Act
+        SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, -1, commonsRepository, userCommonsRepository,
+                userRepository);
+        
+        setCowHealthJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Setting cow health...
+                Cow health must be between 0 and 100""";
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+    void test_invalid_health_greater_than_100() throws Exception {
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+
+        // Act
+        SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 101, commonsRepository, userCommonsRepository,
+                userRepository);
+        
+        setCowHealthJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Setting cow health...
+                Cow health must be between 0 and 100""";
+        assertEquals(expected, jobStarted.getLog());
+    }
+
+    @Test
+        void test_boundary_health_equal_100() throws Exception {
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+
+        // Act
+        SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 100, commonsRepository, userCommonsRepository,
+                userRepository);
+        
+        setCowHealthJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Setting cow health...
+                Commons test commons
+                Cow health has been set!""";
+        assertEquals(expected, jobStarted.getLog());
+        }
+
+        @Test
+        void test_boundary_health_equal_0() throws Exception {
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
+
+        // Act
+        SetCowHealthJob setCowHealthJob = new SetCowHealthJob(117, 0, commonsRepository, userCommonsRepository,
+                userRepository);
+        
+        setCowHealthJob.accept(ctx);
+
+        // Assert
+        String expected = """
+                Setting cow health...
+                Commons test commons
+                Cow health has been set!""";
+        assertEquals(expected, jobStarted.getLog());
+        }
+
 }


### PR DESCRIPTION
## Overview
In this PR, I added backend checks to `newCowHealth` for boundary [0-100].

## Screenshots (Optional)

## Feedback Request (Optional)

## Future Possibilities (Optional)

## Validation (Optional)
This is a simple modification, so the code explains itself. It should've printed an error message in the log, but since there is frontend check, you cannot directly use webpage to post an invalid request.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #49 
