### PR TITLE
fix:Admin page story now shows the fixtures for commons

### DIFF
--- a/frontend/src/stories/pages/AdminListCommonPage.stories.js
+++ b/frontend/src/stories/pages/AdminListCommonPage.stories.js
@@ -1,12 +1,28 @@
 import React from 'react';
-
 import AdminListCommonPage from "main/pages/AdminListCommonPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from 'msw';
+import commonsPlusFixtures from 'fixtures/commonsPlusFixtures';
 
 export default {
     title: 'pages/AdminListCommonPage',
     component: AdminListCommonPage
 };
 
-const Template = () => <AdminListCommonPage />;
+export const adminListPage = () => <AdminListCommonPage />;
 
-export const Default = Template.bind({});
+adminListPage.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/commons/allplus', (_req, res, ctx) => {
+            return res(ctx.json(commonsPlusFixtures.threeCommonsPlus));
+        }),
+    ]
+}


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add the commons fixtures to the admin page list commons story. This way, devs can see what their changes to this page look like.

## Screenshots (Optional)
<img width="1370" alt="Screenshot 2023-08-15 at 10 44 08 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/41165204/51d3fb15-5712-4a61-8ca5-f39f637ab242">

## Link

https://ucsb-cs156-m23.github.io/proj-happycows-m23-10am-4/prs/57/storybook/?path=/story/pages-adminlistcommonpage--admin-list-page

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #56 
