### PR TITLE
FIX: Removed 404 Error Page on Navigation and Reload

### DIFF
--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
     - uses: szenius/set-timezone@v1.2

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,4 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useState, useEffect, useContext, createContext } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -17,82 +16,43 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
-const NavigationContext = createContext();
-
-// Custom hook to handle navigation
-const useNavigation = () => {
-  const [currentComponent, setCurrentComponent] = useState(null);
-  const [isNavigating, setIsNavigating] = useState(false);
-
-  const handleNavigationStart = (Component) => {
-    setCurrentComponent(<Component />);
-    setIsNavigating(true);
-  };
-
-  const handleNavigationEnd = () => {
-    setIsNavigating(false);
-  };
-
-  return { currentComponent, isNavigating, handleNavigationStart, handleNavigationEnd };
-};
-
-function RouteWrapper({ component: Component, ...props }) {
-  const { handleNavigationStart, handleNavigationEnd } = useContext(NavigationContext);
-
-  useEffect(() => {
-    handleNavigationStart(Component);
-
-    // You might want to use a more specific way to determine when navigation has ended.
-    // This is just an example; the actual implementation will depend on your routing logic.
-    const timer = setTimeout(() => {
-      handleNavigationEnd();
-    }, 500); // This delay should match the time it takes for the component to load.
-
-    return () => clearTimeout(timer);
-  }, [Component, handleNavigationStart, handleNavigationEnd]);
-
-  return <Component {...props} />;
-}
-
 function App() {
-
   const { data: currentUser } = useCurrentUser();
-  const { currentComponent, isNavigating, handleNavigationStart, handleNavigationEnd } = useNavigation();
+
+  // Define admin routes
+  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
+    <>
+      <Route path="/admin/users" element={<AdminUsersPage />} />
+      <Route path="/admin/jobs" element={<AdminJobsPage />} />
+      <Route path="/admin/reports" element={<AdminReportsPage />} />
+      <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
+      <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
+      <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
+      <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+    </>
+  ) : null;
+
+  // Define user routes
+  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
+    <>
+      <Route path="/profile" element={<ProfilePage />} />
+      <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
+      <Route path="/play/:commonsId" element={<PlayPage />} />
+    </>
+  ) : null;
+
+  // Choose the homepage based on roles
+  const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
+    ? <Route path="/" element={<HomePage />} /> 
+    : <Route path="/" element={<LoginPage />} />;
 
   return (
     <BrowserRouter>
       <Routes>
-        {
-          (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
-        }
-        {
-          !(hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<LoginPage />} />
-        }
-        {
-          hasRole(currentUser, "ROLE_ADMIN") && 
-          (
-            <>
-              <Route path="/admin/users" element={<AdminUsersPage />} />
-              <Route path="/admin/jobs" element={<AdminJobsPage />} />
-              <Route path="/admin/reports" element={<AdminReportsPage />} />
-              <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
-              <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
-              <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
-              <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
-            </>
-          )
-        }
-        {
-          hasRole(currentUser, "ROLE_USER") && 
-          (
-            <>
-             <Route path="/profile" element={<ProfilePage />} />
-             <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
-             <Route path="/play/:commonsId" element={<PlayPage />} />
-           </>
-          )
-        }
-        <Route path="*" element={<NotFoundPage />} />
+        {homeRoute}
+        {adminRoutes}
+        {userRoutes}
+        <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,13 +19,12 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
-  const { data: currentUser } = useCurrentUser();
-  const [isLoading, setIsLoading] = useState(true);
+  const useCurrentUserReturn = useCurrentUser();
+  const { data: currentUser } = useCurrentUserReturn;
+  const [isLoading, setIsLoading] = useState(useCurrentUserReturn?.initialData);
 
   // Delay setting the loading state to false
   useEffect(() => {
-    if (!currentUser?.initialData)
-      setIsLoading(false);
     setTimeout(() => {
       setIsLoading(false);
     }, 2000); // 2000ms delay

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -21,7 +21,7 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-    <BrowserRouter>
+    <HashRouter>
       <Routes>
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
@@ -55,7 +55,7 @@ function App() {
         }
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,11 +16,10 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
-function App() {
+function AdminRoutes() {
   const { data: currentUser } = useCurrentUser();
-
-  // Define admin routes
-  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
+  if (!hasRole(currentUser, "ROLE_ADMIN")) return null;
+  return (
     <>
       <Route path="/admin/users" element={<AdminUsersPage />} />
       <Route path="/admin/jobs" element={<AdminJobsPage />} />
@@ -30,28 +29,34 @@ function App() {
       <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
       <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
     </>
-  ) : null;
+  );
+}
 
-  // Define user routes
-  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
+function UserRoutes() {
+  const { data: currentUser } = useCurrentUser();
+  if (!hasRole(currentUser, "ROLE_USER")) return null;
+  return (
     <>
       <Route path="/profile" element={<ProfilePage />} />
       <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
       <Route path="/play/:commonsId" element={<PlayPage />} />
     </>
-  ) : null;
+  );
+}
 
-  // Choose the homepage based on roles
-  const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
-    ? <Route path="/" element={<HomePage />} /> 
-    : <Route path="/" element={<LoginPage />} />;
+function HomeRoutes() {
+  const {data: currentUser } = useCurrentUser();
+  return hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER") 
+  ? <HomePage /> : <LoginPage />;
+}
 
+function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {homeRoute}
-        {adminRoutes}
-        {userRoutes}
+        <Route path="/" element={<HomeRoutes />} /> {/* Home page routing */}
+        <Route path="*" element={<AdminRoutes />} />
+        <Route path="*" element={<UserRoutes />} />
         <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
+import { StaticRouter } from "react-router-dom/server";
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -21,7 +22,7 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-    <BrowserRouter>
+    <StaticRouter>
       <Routes>
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
@@ -55,7 +56,7 @@ function App() {
         }
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-    </BrowserRouter>
+    </StaticRouter>
   );
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,17 +19,13 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
-  const useCurrentUserReturn = useCurrentUser();
-  const { data: currentUser } = useCurrentUserReturn;
+  const { data: currentUser } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(true);
 
   // Delay setting the loading state to false
   useEffect(() => {
-    setIsLoading(!currentUser?.root);
-    setTimeout(() => {
-      setIsLoading(false);
-    }, 2000); // 2000ms delay
-  }, []);
+    setIsLoading(currentUser?.initialData);
+  }, [currentUser]);
 
   // Define admin routes
   const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,43 +17,42 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
-
   const { data: currentUser } = useCurrentUser();
+
+  // Define admin routes
+  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
+    <>
+      <Route path="/admin/users" element={<AdminUsersPage />} />
+      <Route path="/admin/jobs" element={<AdminJobsPage />} />
+      <Route path="/admin/reports" element={<AdminReportsPage />} />
+      <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
+      <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
+      <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
+      <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+    </>
+  ) : null;
+
+  // Define user routes
+  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
+    <>
+      <Route path="/profile" element={<ProfilePage />} />
+      <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
+      <Route path="/play/:commonsId" element={<PlayPage />} />
+    </>
+  ) : null;
+
+  // Choose the homepage based on roles
+  const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
+    ? <Route path="/" element={<HomePage />} /> 
+    : <Route path="/" element={<LoginPage />} />;
 
   return (
     <BrowserRouter>
       <Routes>
-        {
-          (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
-        }
-        {
-          !(hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<LoginPage />} />
-        }
-        {
-          hasRole(currentUser, "ROLE_ADMIN") && 
-          (
-            <>
-              <Route path="/admin/users" element={<AdminUsersPage />} />
-              <Route path="/admin/jobs" element={<AdminJobsPage />} />
-              <Route path="/admin/reports" element={<AdminReportsPage />} />
-              <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
-              <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
-              <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
-              <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
-            </>
-          )
-        }
-        {
-          hasRole(currentUser, "ROLE_USER") && 
-          (
-            <>
-             <Route path="/profile" element={<ProfilePage />} />
-             <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
-             <Route path="/play/:commonsId" element={<PlayPage />} />
-           </>
-          )
-        }
-        <Route path="*" element={<NotFoundPage />} />
+        {homeRoute}
+        {adminRoutes}
+        {userRoutes}
+        <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useState, useEffect } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -17,7 +18,19 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
+
   const { data: currentUser } = useCurrentUser();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (currentUser) {
+      setIsLoading(false);
+    }
+  }, [currentUser]);
+
+  if (isLoading) {
+    return <div>Loading...</div>; // Replace with your actual loading component or spinner
+  }
 
   // Define admin routes
   const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -21,7 +21,7 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-    <HashRouter basename="/">
+    <BrowserRouter>
       <Routes>
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
@@ -55,7 +55,7 @@ function App() {
         }
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-    </HashRouter>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,4 @@
-import { Routes, Route } from "react-router-dom";
-import { StaticRouter } from "react-router-dom/server";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -22,7 +21,7 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-    <StaticRouter>
+    <BrowserRouter>
       <Routes>
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
@@ -56,7 +55,7 @@ function App() {
         }
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-    </StaticRouter>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext, createContext } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -18,6 +18,8 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import { NavigationContext } from "main/contexts/NavigationContext";
 
+const NavigationContext = createContext();
+
 function RouteWrapper({ component: Component, ...props }) {
   const { handleRouteChange } = useContext(NavigationContext);
 
@@ -27,8 +29,6 @@ function RouteWrapper({ component: Component, ...props }) {
 
   return <Component {...props} onNavigate={handleNavigate} />;
 }
-
-const NavigationContext = createContext();
 
 function App() {
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,4 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useState, useEffect } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
@@ -20,12 +19,6 @@ import NotFoundPage from "main/pages/NotFoundPage";
 
 function App() {
   const { data: currentUser } = useCurrentUser();
-  const [isLoading, setIsLoading] = useState(true);
-
-  // Delay setting the loading state to false
-  useEffect(() => {
-    setIsLoading(currentUser?.initialData);
-  }, [currentUser]);
 
   // Define admin routes
   const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
@@ -56,14 +49,14 @@ function App() {
 
   return (
     <BrowserRouter>
-      {isLoading ? (
-          <LoadingPage /> // Loading screen
+      {currentUser?.initialData ? (
+          <LoadingPage />
         ) : (
         <Routes>
           {homeRoute}
           {adminRoutes}
           {userRoutes}
-          <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       )}
     </BrowserRouter>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,6 @@ import AdminReportsPage from "main/pages/AdminReportsPage";
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
-import { NavigationContext } from "main/contexts/NavigationContext";
 
 const NavigationContext = createContext();
 
@@ -44,9 +43,13 @@ function App() {
     }
   }, [currentUser]);
 
-  // if (isLoading) {
-  //   return <div>Loading...</div>; // Replace with actual loading component or spinner
-  // }
+  // Define a state to handle the current component
+  const [currentComponent, setCurrentComponent] = useState(null);
+
+  // Define a function that you want to make available to all routes
+  const handleRouteChange = (component) => {
+    setCurrentComponent(component);
+  };
 
   // Define admin routes
   const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
@@ -79,10 +82,11 @@ function App() {
     <BrowserRouter>
       <NavigationContext.Provider value={{ handleRouteChange }}>
         <Routes>
+          {isLoading && currentComponent}
           {homeRoute}
           {adminRoutes}
           {userRoutes}
-          !isLoading && <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
+          !{isLoading} && <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
         </Routes>
       </NavigationContext.Provider>
     </BrowserRouter>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ import NotFoundPage from "main/pages/NotFoundPage";
 function App() {
   const useCurrentUserReturn = useCurrentUser();
   const { data: currentUser } = useCurrentUserReturn;
-  const [isLoading, setIsLoading] = useState(useCurrentUserReturn?.initialData);
+  const [isLoading, setIsLoading] = useState(!currentUser?.root);
 
   // Delay setting the loading state to false
   useEffect(() => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useState, useEffect, useContext, createContext } from 'react';
+import { useState, useContext, createContext } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -73,7 +73,6 @@ function App() {
       <NavigationContext.Provider value={{ handleRouteChange }}>
         {currentComponent ? currentComponent : (
           <Routes>
-            {isLoading && currentComponent}
             {homeRoute}
             {adminRoutes}
             {userRoutes}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,12 +24,12 @@ const useNavigation = () => {
   const [currentComponent, setCurrentComponent] = useState(null);
   const [isNavigating, setIsNavigating] = useState(false);
 
-  const handleNavigationStart = () => {
+  const handleNavigationStart = (Component) => {
+    setCurrentComponent(<Component />);
     setIsNavigating(true);
   };
 
-  const handleNavigationEnd = (Component) => {
-    setCurrentComponent(<Component />);
+  const handleNavigationEnd = () => {
     setIsNavigating(false);
   };
 
@@ -40,12 +40,12 @@ function RouteWrapper({ component: Component, ...props }) {
   const { handleNavigationStart, handleNavigationEnd } = useContext(NavigationContext);
 
   useEffect(() => {
-    handleNavigationStart();
+    handleNavigationStart(Component);
 
     // You might want to use a more specific way to determine when navigation has ended.
     // This is just an example; the actual implementation will depend on your routing logic.
     const timer = setTimeout(() => {
-      handleNavigationEnd(Component);
+      handleNavigationEnd();
     }, 500); // This delay should match the time it takes for the component to load.
 
     return () => clearTimeout(timer);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useState, useEffect } from 'react';
 import HomePage from "main/pages/HomePage";
+import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
 import LeaderboardPage from "main/pages/LeaderboardPage";
@@ -58,7 +59,7 @@ function App() {
   return (
     <BrowserRouter>
       {isLoading ? (
-          <div>Loading...</div> // Loading screen
+          <LoadingPage /> // Loading screen
         ) : (
         <Routes>
           {homeRoute}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,9 +24,11 @@ function App() {
 
   // Delay setting the loading state to false
   useEffect(() => {
+    if (!currentUser?.initialData)
+      setIsLoading(false);
     setTimeout(() => {
       setIsLoading(false);
-    }, 200); // 200ms delay
+    }, 2000); // 2000ms delay
   }, []);
 
   // Define admin routes

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -59,45 +59,41 @@ function App() {
   const { data: currentUser } = useCurrentUser();
   const { currentComponent, isNavigating, handleNavigationStart, handleNavigationEnd } = useNavigation();
 
-  // Define admin routes
-  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
-    <>
-      <Route path="/admin/users" element={<RouteWrapper component={AdminUsersPage} />} />
-      <Route path="/admin/jobs" element={<RouteWrapper component={AdminJobsPage} />} />
-      <Route path="/admin/reports" element={<RouteWrapper component={AdminReportsPage} />} />
-      <Route path="/admin/report/:reportId" element={<RouteWrapper component={AdminViewReportPage} />} />
-      <Route path="/admin/createcommons" element={<RouteWrapper component={AdminCreateCommonsPage} />} />
-      <Route path="/admin/listcommons" element={<RouteWrapper component={AdminListCommonsPage} />} />
-      <Route path="/admin/editcommons/:id" element={<RouteWrapper component={AdminEditCommonsPage} />} />
-    </>
-  ) : null;
-
-  // Define user routes
-  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
-    <>
-      <Route path="/profile" element={<RouteWrapper component={ProfilePage} />} />
-      <Route path="/leaderboard/:commonsId" element={<RouteWrapper component={LeaderboardPage} />}/>
-      <Route path="/play/:commonsId" element={<RouteWrapper component={PlayPage} />} />
-    </>
-  ) : null;
-
-  // Choose the homepage based on roles
-  const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
-    ? <Route path="/" element={<RouteWrapper component={HomePage} />} /> 
-    : <Route path="/" element={<RouteWrapper component={LoginPage} />} />;
-
   return (
     <BrowserRouter>
-      <NavigationContext.Provider value={{ handleNavigationStart, handleNavigationEnd }}>
-        {isNavigating ? currentComponent : (
-          <Routes>
-            {homeRoute}
-            {adminRoutes}
-            {userRoutes}
-            <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
-          </Routes>
-        )}
-      </NavigationContext.Provider>
+      <Routes>
+        {
+          (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />
+        }
+        {
+          !(hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<LoginPage />} />
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && 
+          (
+            <>
+              <Route path="/admin/users" element={<AdminUsersPage />} />
+              <Route path="/admin/jobs" element={<AdminJobsPage />} />
+              <Route path="/admin/reports" element={<AdminReportsPage />} />
+              <Route path="/admin/report/:reportId" element={<AdminViewReportPage />} />
+              <Route path="/admin/createcommons" element={<AdminCreateCommonsPage />} />
+              <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
+              <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && 
+          (
+            <>
+             <Route path="/profile" element={<ProfilePage />} />
+             <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
+             <Route path="/play/:commonsId" element={<PlayPage />} />
+           </>
+          )
+        }
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,23 +32,13 @@ function RouteWrapper({ component: Component, ...props }) {
 function App() {
 
   const { data: currentUser } = useCurrentUser();
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (currentUser) {
-      // Delay setting the loading state to false
-      setTimeout(() => {
-        setIsLoading(false);
-      }, 200); // Adjust the delay as needed
-    }
-  }, [currentUser]);
-
-  // Define a state to handle the current component
   const [currentComponent, setCurrentComponent] = useState(null);
 
-  // Define a function that you want to make available to all routes
   const handleRouteChange = (component) => {
-    setCurrentComponent(component);
+    // Keep the old component rendered with a delay
+    setTimeout(() => {
+      setCurrentComponent(component);
+    }, 200);
   };
 
   // Define admin routes
@@ -81,13 +71,15 @@ function App() {
   return (
     <BrowserRouter>
       <NavigationContext.Provider value={{ handleRouteChange }}>
-        <Routes>
-          {isLoading && currentComponent}
-          {homeRoute}
-          {adminRoutes}
-          {userRoutes}
-          !{isLoading} && <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
-        </Routes>
+        {currentComponent ? currentComponent : (
+          <Routes>
+            {isLoading && currentComponent}
+            {homeRoute}
+            {adminRoutes}
+            {userRoutes}
+            <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
+          </Routes>
+        )}
       </NavigationContext.Provider>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useState, useEffect } from 'react';
 import HomePage from "main/pages/HomePage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
@@ -16,10 +17,19 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
-function AdminRoutes() {
+function App() {
   const { data: currentUser } = useCurrentUser();
-  if (!hasRole(currentUser, "ROLE_ADMIN")) return null;
-  return (
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Delay setting the loading state to false
+  useEffect(() => {
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 200); // 200ms delay
+  }, []);
+
+  // Define admin routes
+  const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
     <>
       <Route path="/admin/users" element={<AdminUsersPage />} />
       <Route path="/admin/jobs" element={<AdminJobsPage />} />
@@ -29,36 +39,34 @@ function AdminRoutes() {
       <Route path="/admin/listcommons" element={<AdminListCommonsPage />} />
       <Route path="/admin/editcommons/:id" element={<AdminEditCommonsPage />} />
     </>
-  );
-}
+  ) : null;
 
-function UserRoutes() {
-  const { data: currentUser } = useCurrentUser();
-  if (!hasRole(currentUser, "ROLE_USER")) return null;
-  return (
+  // Define user routes
+  const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
     <>
       <Route path="/profile" element={<ProfilePage />} />
       <Route path="/leaderboard/:commonsId" element={<LeaderboardPage />}/>
       <Route path="/play/:commonsId" element={<PlayPage />} />
     </>
-  );
-}
+  ) : null;
 
-function HomeRoutes() {
-  const {data: currentUser } = useCurrentUser();
-  return hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER") 
-  ? <HomePage /> : <LoginPage />;
-}
+  // Choose the homepage based on roles
+  const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
+    ? <Route path="/" element={<HomePage />} /> 
+    : <Route path="/" element={<LoginPage />} />;
 
-function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HomeRoutes />} /> {/* Home page routing */}
-        <Route path="*" element={<AdminRoutes />} />
-        <Route path="*" element={<UserRoutes />} />
-        <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
-      </Routes>
+      {isLoading ? (
+          <div>Loading...</div> // Loading screen
+        ) : (
+        <Routes>
+          {homeRoute}
+          {adminRoutes}
+          {userRoutes}
+          <Route path="*" element={<NotFoundPage />} /> {/* Fallback 404 route */}
+        </Routes>
+      )}
     </BrowserRouter>
   );
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ function App() {
   const { data: currentUser } = useCurrentUser();
 
   return (
-    <HashRouter>
+    <HashRouter basename="/">
       <Routes>
         {
           (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) && <Route path="/" element={<HomePage />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,7 +20,6 @@ import NotFoundPage from "main/pages/NotFoundPage";
 function App() {
   const { data: currentUser } = useCurrentUser();
 
-  // Define admin routes
   const adminRoutes = hasRole(currentUser, "ROLE_ADMIN") ? (
     <>
       <Route path="/admin/users" element={<AdminUsersPage />} />
@@ -33,7 +32,6 @@ function App() {
     </>
   ) : null;
 
-  // Define user routes
   const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
     <>
       <Route path="/profile" element={<ProfilePage />} />
@@ -42,16 +40,14 @@ function App() {
     </>
   ) : null;
 
-  // Choose the homepage based on roles
   const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
     ? <Route path="/" element={<HomePage />} /> 
     : <Route path="/" element={<LoginPage />} />;
-
+    
+  /* Display the LoadingPage while awaiting currentUser response */
   return (
     <BrowserRouter>
-      {currentUser?.initialData ? (
-          <LoadingPage />
-        ) : (
+      {currentUser?.initialData ? ( <LoadingPage /> ) : ( 
         <Routes>
           {homeRoute}
           {adminRoutes}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,10 +21,11 @@ import NotFoundPage from "main/pages/NotFoundPage";
 function App() {
   const useCurrentUserReturn = useCurrentUser();
   const { data: currentUser } = useCurrentUserReturn;
-  const [isLoading, setIsLoading] = useState(!currentUser?.root);
+  const [isLoading, setIsLoading] = useState(true);
 
   // Delay setting the loading state to false
   useEffect(() => {
+    setIsLoading(!currentUser?.root);
     setTimeout(() => {
       setIsLoading(false);
     }, 2000); // 2000ms delay

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -38,7 +38,7 @@ function App() {
     // Keep the old component rendered with a delay
     setTimeout(() => {
       setCurrentComponent(component);
-    }, 200);
+    }, 5000);
   };
 
   // Define admin routes

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -43,8 +43,9 @@ function App() {
   const homeRoute = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_USER")) 
     ? <Route path="/" element={<HomePage />} /> 
     : <Route path="/" element={<LoginPage />} />;
-    
-  /* Display the LoadingPage while awaiting currentUser response */
+
+  /*  Display the LoadingPage while awaiting currentUser 
+      response to prevent the NotFoundPage from displaying */
   return (
     <BrowserRouter>
       {currentUser?.initialData ? ( <LoadingPage /> ) : ( 

--- a/frontend/src/main/pages/LoadingPage.js
+++ b/frontend/src/main/pages/LoadingPage.js
@@ -1,0 +1,11 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HomePage() {  
+  return (
+    <div data-testid={"LoadingPage-main-div"}>
+      <BasicLayout>
+        
+      </BasicLayout>
+    </div>
+  )
+}

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import CommonsForm from "main/components/Commons/CommonsForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import commonsFixtures from "fixtures/commonsFixtures"

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import CommonsForm from "main/components/Commons/CommonsForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import commonsFixtures from "fixtures/commonsFixtures"

--- a/frontend/src/tests/components/Commons/CommonsSelect.test.js
+++ b/frontend/src/tests/components/Commons/CommonsSelect.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import CommonsSelect from "main/components/Commons/CommonsSelect";
 import { QueryClient, QueryClientProvider } from "react-query";
 import commonsFixtures from "fixtures/commonsFixtures"

--- a/frontend/src/tests/components/Commons/CommonsSelect.test.js
+++ b/frontend/src/tests/components/Commons/CommonsSelect.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import CommonsSelect from "main/components/Commons/CommonsSelect";
 import { QueryClient, QueryClientProvider } from "react-query";
 import commonsFixtures from "fixtures/commonsFixtures"

--- a/frontend/src/tests/components/Commons/HealthStrategiesUpdateDropdown.test.js
+++ b/frontend/src/tests/components/Commons/HealthStrategiesUpdateDropdown.test.js
@@ -1,5 +1,5 @@
 import {  render, screen, waitFor } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
 

--- a/frontend/src/tests/components/Commons/HealthStrategiesUpdateDropdown.test.js
+++ b/frontend/src/tests/components/Commons/HealthStrategiesUpdateDropdown.test.js
@@ -1,5 +1,5 @@
 import {  render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
 

--- a/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportForm.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import InstructorReportSpecificCommonsForm from "main/components/Jobs/InstructorReportSpecificCommonsForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.js
+++ b/frontend/src/tests/components/Jobs/InstructorReportSpecificCommonsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import InstructorReportSpecificCommonsForm from "main/components/Jobs/InstructorReportSpecificCommonsForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/components/Jobs/SetCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/SetCowHealthForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import SetCowHealthForm from "main/components/Jobs/SetCowHealthForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/components/Jobs/SetCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/SetCowHealthForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import SetCowHealthForm from "main/components/Jobs/SetCowHealthForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 import AxiosMockAdapter from "axios-mock-adapter";

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import TestJobsForm from "main/components/Jobs/TestJobForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/components/Jobs/TestJobsForm.test.js
+++ b/frontend/src/tests/components/Jobs/TestJobsForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import TestJobsForm from "main/components/Jobs/TestJobForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { HashRouter as Router } from "react-router-dom";
+import { MemoryRouter as Router } from "react-router-dom";
 import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
 import jobsFixtures from "fixtures/jobsFixtures";
 

--- a/frontend/src/tests/pages/LoadingPage.test.js
+++ b/frontend/src/tests/pages/LoadingPage.test.js
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import LoadingPage from "main/pages/LoadingPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+        commonsId: 1
+    }),
+    useNavigate: () => mockNavigate
+}));
+
+describe("LoadingPage tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing when lists return empty list", () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, []);
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LoadingPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const mainDiv = screen.getByTestId("LoadingPage-main-div");
+        expect(mainDiv).toBeInTheDocument();
+
+    });
+
+});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we remove the issue of the 404 Error screen appearing briefly whenever a page is loaded or reloaded. We accomplish this by rendering a blank page until the correct one has been served to the client. This also has a secondary benefit of reducing page loading times, as it removes the initial React Router query (Which resulted in 404).

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
*Insert absence of 404 Error*

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- Rather than serving a blank page, we could maintain the current page (if applicable) until the new one is ready.
- It could also be nice to refactor the app to use the newer React data routers, which have some nice features for mitigating similar issues

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Deploy this branch on dokku (localhost is too fast to replicate the issue).
2. Navigate to a page other than root 
3. Reload the page repeatedly and make sure “404” never appears

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #33 