### PR TITLE
Chat message API

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
@@ -1,18 +1,11 @@
 package edu.ucsb.cs156.happiercows.config;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +22,6 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
@@ -3,20 +3,16 @@ package edu.ucsb.cs156.happiercows.controllers;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.errors.NoCowsException;
 import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 
-// import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.models.CurrentUser;
 import edu.ucsb.cs156.happiercows.services.CurrentUserService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.Map;
 
-@Slf4j
 public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageController.java
@@ -1,0 +1,118 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+import edu.ucsb.cs156.happiercows.repositories.ChatMessageRepository;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+import java.util.Optional;
+
+@Tag(name = "Chat Message")
+@RequestMapping("/api/chat")
+@RestController
+public class ChatMessageController extends ApiController{
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get all chat messages", description = "Get all chat messages associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public ResponseEntity<Object> getAllChatMessages(@Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                            @Parameter(name="page") @RequestParam int page,
+                                            @Parameter(name="size") @RequestParam int size) {
+        
+        // Make sure the user is part of the commons or is an admin
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+        Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+        if (!userCommonsLookup.isPresent() && !u.isAdmin()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Return the list of non-hidden chat messages
+        Page<ChatMessage> messages = chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        return ResponseEntity.ok(messages);
+    }
+
+    @Operation(summary = "Get all chat messages", description = "Get all chat messages associated with a specific commons, even the hidden ones")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/get/all")
+    public ResponseEntity<Object> getAllChatMessages(@Parameter(description = "The id of the common") @RequestParam Long commonsId) {
+        
+        // Return the list of chat messages
+        Iterable<ChatMessage> messages = chatMessageRepository.findAllByCommonsId(commonsId);
+        return ResponseEntity.ok(messages);
+    }
+
+    @Operation(summary = "Create a chat message", description = "Create a chat message associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public ResponseEntity<Object> createChatMessage(@Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                                    @Parameter(description = "The message to be sent") @RequestParam String content) {
+        
+        // Make sure the user is part of the commons
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+        Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+        if (!userCommonsLookup.isPresent() && !u.isAdmin()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Create the chat message
+        ChatMessage chatMessage = ChatMessage.builder()
+        .commonsId(commonsId)
+        .userId(userId)
+        .message(content)
+        .hidden(false)
+        .dm(false)
+        .toUserId(0)
+        .build();
+
+        return ResponseEntity.ok(chatMessage);
+    }
+
+    @Operation(summary = "Delete a chat message", description = "Delete a chat message associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public ResponseEntity<Object> deleteChatMessage(@Parameter(description = "The id of the chat message") @RequestParam Long chatMessageId) {
+        
+        // Delete the chat message
+        Optional<ChatMessage> chatMessageLookup = chatMessageRepository.findById(chatMessageId);
+        if (!chatMessageLookup.isPresent()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        ChatMessage chatMessage = chatMessageLookup.get();
+        chatMessage.setHidden(true);
+        chatMessageRepository.save(chatMessage);
+
+        return ResponseEntity.ok(chatMessage);
+    }
+
+    
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -9,7 +9,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,8 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
 @RestController
-@Slf4j
-
 public class ProfitsController extends ApiController {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
@@ -1,20 +1,15 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import edu.ucsb.cs156.happiercows.entities.Profit;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.ReportLine;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.helpers.ReportCSVHelper;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
 import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.http.HttpHeaders;
@@ -26,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.catalina.session.FileStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -25,11 +25,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import org.springframework.http.ResponseEntity;
-import javax.validation.Valid;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User Commons")
 @RequestMapping("/api/usercommons")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserInfoController.java
@@ -1,8 +1,6 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.models.CurrentUser;
-import edu.ucsb.cs156.happiercows.services.CurrentUserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/ChatMessage.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/ChatMessage.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.CreationTimestamp;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "chat_message")
+public class ChatMessage {
+    
+    // Unique Message Id
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    // The user that created this message and the commons that it belongs in
+    private long userId;
+    private long commonsId;
+
+    // Message timestamp and payload
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date timestamp;
+    private String message;
+
+    // For future use in DMs
+    private boolean dm;
+    private long toUserId;
+
+    // We do not delete messages in the backend, we just hide them
+    @Builder.Default
+    private boolean hidden = false;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.happiercows.entities;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.persistence.*;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import javax.persistence.*;

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
@@ -9,8 +9,6 @@ import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import edu.ucsb.cs156.happiercows.entities.ReportLine;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 /*
  * This code is based on 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -5,9 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
 import lombok.AccessLevel;
-import org.springframework.beans.factory.annotation.Value;
-
-
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
@@ -18,5 +20,5 @@ public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")
-    ChatMessage findById(long id);
+    Optional<ChatMessage> findById(long id);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+
+@Repository
+public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -11,10 +11,10 @@ import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false", nativeQuery = true)
     Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
 
-    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId", nativeQuery = true)
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -1,11 +1,22 @@
 package edu.ucsb.cs156.happiercows.repositories;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    
+    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
+    Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
+
+    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId")
+    Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
+
+    @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")
+    ChatMessage findById(long id);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -13,10 +13,10 @@ import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false", nativeQuery = true)
+    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
     Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
 
-    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId", nativeQuery = true)
+    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId")
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
@@ -308,4 +308,24 @@ public class ChatMessageControllerTests extends ControllerTestCase {
         assertEquals(expectedResponseString, responseString);
     }
 
+    // Cannot delete chat messages that don't exist
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCannotDeleteChatMessagesThatDontExist() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        //act 
+        mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findById(messageId);
+        verify(chatMessageRepository, times(0)).save(any(ChatMessage.class));
+    }
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
@@ -1,0 +1,311 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.repositories.ChatMessageRepository;
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = ChatMessageController.class)
+@Import(ChatMessageController.class)
+@AutoConfigureDataJpa
+public class ChatMessageControllerTests extends ControllerTestCase {
+    
+    @MockBean
+    ChatMessageRepository chatMessageRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanGetAllChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).build();
+
+        Iterable<ChatMessage> iterableOfChatMessages = Arrays.asList(chatMessage1, chatMessage2);
+
+        when(chatMessageRepository.findAllByCommonsId(commonsId)).thenReturn(iterableOfChatMessages);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get/all?commonsId={commonsId}", commonsId))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findAllByCommonsId(commonsId);
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(iterableOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCannotUseGetAllAPIEndpoint() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).build();
+
+        Iterable<ChatMessage> iterableOfChatMessages = Arrays.asList(chatMessage1, chatMessage2);
+
+        when(chatMessageRepository.findAllByCommonsId(commonsId)).thenReturn(iterableOfChatMessages);
+
+        // act
+        mockMvc.perform(get("/api/chat/get/all?commonsId={commonsId}", commonsId))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).findAllByCommonsId(commonsId);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(pageOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        // act
+        mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isForbidden()).andReturn();
+        
+        // assert
+        verify(chatMessageRepository, times(0)).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+    
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).save(any(ChatMessage.class));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCannotDeleteChatMessages() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        //act 
+        mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).delete(any(ChatMessage.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanDeleteChatMessages() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        ChatMessage chatMessage = ChatMessage.builder().id(messageId).build();
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.of(chatMessage));
+
+        //act 
+        MvcResult response = mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findById(messageId);
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        chatMessage.setHidden(true);
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(pageOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
@@ -2,8 +2,6 @@ package edu.ucsb.cs156.happiercows.entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import edu.ucsb.cs156.happiercows.entities.User;
-
 import org.junit.jupiter.api.Test;
 
 public class UserTests {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
@@ -10,9 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 
 @RestClientTest(InstructorReportJobFactory.class)

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
@@ -4,20 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -1,7 +1,5 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,22 +9,12 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-
-// @Slf4j
-// @ExtendWith(SpringExtension.class)
-// @ContextConfiguration 
 
 @RestClientTest(ScheduledJobs.class)
 @AutoConfigureDataJpa

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +11,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Slf4j
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration 
 public class TestJobTests {

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -2,23 +2,12 @@ package edu.ucsb.cs156.happiercows.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
-
-
-import javax.persistence.Column;
-import javax.persistence.Enumerated;
-import javax.persistence.TemporalType;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-
-import edu.ucsb.cs156.happiercows.ControllerTestCase;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -1,14 +1,10 @@
 package edu.ucsb.cs156.happiercows.services;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;

--- a/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
@@ -2,24 +2,13 @@ package edu.ucsb.cs156.happiercows.testconfig;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.happiercows.entities.User;
-import edu.ucsb.cs156.happiercows.models.CurrentUser;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.CurrentUserServiceImpl;
 
 @Slf4j


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we implement the MVP for the chat backend. There is a post request where users of a common and admins can post messages, a get for users and admins to get messages, a get for admins to get all messages, including the hidden ones, and a delete for admins to hide messages. Those that do not follow the specifications in #1 are not part of the MVP. They will later be updated to conform. 

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #46 
