### PR TITLE
Cow selling price is proportional to cow health

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -117,7 +117,8 @@ public class UserCommonsController extends ApiController {
 
 
         if(userCommons.getNumOfCows() >= 1 ){
-          userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
+          double cowValue = commons.getCowPrice() * userCommons.getCowHealth() / 100;
+          userCommons.setTotalWealth(userCommons.getTotalWealth() + cowValue);
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
           userCommons.setCowsSold(userCommons.getCowsSold() + 1);
         }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -203,9 +203,11 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
         UserCommons origUserCommons = getTestUserCommons();
         origUserCommons.setCowsSold(1);
+        origUserCommons.setCowHealth(50);
 
         UserCommons updatedUserCommons = getTestUserCommons();
-        updatedUserCommons.setTotalWealth(300 + testCommons.getCowPrice());
+        updatedUserCommons.setCowHealth(50);
+        updatedUserCommons.setTotalWealth(300 + testCommons.getCowPrice() * 0.5);
         updatedUserCommons.setNumOfCows(0);
         updatedUserCommons.setCowsSold(2);
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we alter selling logic in the backend controller for the user commons. We make it so that, when a cow is sold, the user's wealth is increased by the cow price times the cow health as a percentage.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Buy and sell some cows a below 100% health

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #70 
