### PR TITLE
Feature: ChatMessageCreate Component for Chat Frontend

### DIFF
--- a/frontend/src/fixtures/chatMessageFixtures.js
+++ b/frontend/src/fixtures/chatMessageFixtures.js
@@ -1,0 +1,168 @@
+export const chatMessageFixtures = {
+    threeChatMessages: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 3,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This is another test for chat messaging",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 2,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "Hello World How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        }
+    ],
+    oneChatMessage: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        }
+    ],
+    twelveChatMessages: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 2,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "Hello World How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 3,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This is another test for chat messaging",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 4,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 5,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "Hello World How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 6,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This is another test for chat messaging",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 7,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 8,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "Hello World How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 9,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This is another test for chat messaging",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 10,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 11,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "This should not appear",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 12,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This should also be cut off",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+    ],
+}

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -3,6 +3,7 @@ const userCommonsFixtures = {
     [
         {
             "userId": 1,
+            "username": "George Washington",
             "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
@@ -10,12 +11,13 @@ const userCommonsFixtures = {
             "cowsBought": 5,
             "cowsSold": 5,
             "cowDeaths": 5
-        }
+        },
     ],
     threeUserCommons:
     [
         {
             "userId": 1,
+            "username": "George Washington",
             "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
@@ -26,6 +28,7 @@ const userCommonsFixtures = {
         },
         {
             "userId": 2,
+            "username": "John Adams",
             "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
@@ -36,6 +39,7 @@ const userCommonsFixtures = {
         },
         {
             "userId": 3,
+            "username": "Thomas Jefferson",
             "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
@@ -71,6 +75,7 @@ const userCommonsFixtures = {
         },
         {
             "userId": 3,
+            "username": "Thomas Jefferson",
             "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
@@ -80,7 +85,7 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "userId": 3,
+            "userId": 4,
             "username": "James Madison",
             "commonsId":1,
             "totalWealth" : 50,

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -2,22 +2,8 @@ const userCommonsFixtures = {
     oneUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -29,22 +15,8 @@ const userCommonsFixtures = {
     threeUserCommons:
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -53,22 +25,8 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -77,22 +35,8 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "Thomas Jefferson",
-                "givenName": "Thomas",
-                "familyName": "Jefferson",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -104,22 +48,9 @@ const userCommonsFixtures = {
     fiveUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -128,22 +59,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "username": "John Adams",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -152,22 +70,8 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -176,22 +80,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":4,
-            "user": {
-                "id": 3,
-                "fullName": "James Madison",
-                "givenName": "James",
-                "familyName": "Madison",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "James Madison",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -200,22 +91,9 @@ const userCommonsFixtures = {
             "cowDeaths": 100
         },
         {
-            "id":5,
-            "user": {
-                "id": 5,
-                "fullName": "James Monroe",
-                "givenName": "James",
-                "familyName": "Monroe",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 5,
+            "username": "James Monroe",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
@@ -227,22 +105,9 @@ const userCommonsFixtures = {
     tenUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -251,22 +116,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "username": "John Adams",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -275,22 +127,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "Thomas Jefferson",
-                "givenName": "Thomas",
-                "familyName": "Jefferson",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "Thomas Jefferson",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -299,22 +138,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":4,
-            "user": {
-                "id": 3,
-                "fullName": "James Madison",
-                "givenName": "James",
-                "familyName": "Madison",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "James Madison",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -323,22 +149,9 @@ const userCommonsFixtures = {
             "cowDeaths": 100
         },
         {
-            "id":5,
-            "user": {
-                "id": 5,
-                "fullName": "James Monroe",
-                "givenName": "James",
-                "familyName": "Monroe",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 5,
+            "username": "James Monroe",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
@@ -347,22 +160,9 @@ const userCommonsFixtures = {
             "cowDeaths": 60
         },
         {
-            "id":6,
-            "user": {
-                "id": 6,
-                "fullName": "Ancient McDonald",
-                "givenName": "Ancient",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 6,
+            "username": "Ancient McDonald",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -371,22 +171,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":7,
-            "user": {
-                "id": 7,
-                "fullName": "Old McDonald",
-                "givenName": "Old",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 7,
+            "username": "Old McDonald",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -395,22 +182,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":8,
-            "user": {
-                "id": 8,
-                "fullName": "Middle Aged McDonald",
-                "givenName": "Middle Aged",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 8,
+            "username": "Middle Aged McDonald",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -419,22 +193,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":9,
-            "user": {
-                "id": 9,
-                "fullName": "Young McDonald",
-                "givenName": "Young",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 9,
+            "username": "Young McDonald",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -444,21 +205,9 @@ const userCommonsFixtures = {
         },
         {
             "id":10,
-            "user": {
-                "id": 10,
-                "fullName": "Child McDonald",
-                "givenName": "Child",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 10,
+            "username": "Child McDonald",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,

--- a/frontend/src/main/components/Chat/ChatDisplay.js
+++ b/frontend/src/main/components/Chat/ChatDisplay.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import ChatMessageDisplay from 'main/components/Chat/ChatMessageDisplay';
+import { useBackend } from "main/utils/useBackend";
+
+const ChatDisplay = ({ commonsId }) => {
+    const initialMessagePageSize = 10;
+    const refreshRate = 2000;
+    
+    // Stryker disable all
+    const {
+      data: messages
+    } = useBackend(
+        ["/api/chat/get"],
+        {
+            method: "GET",
+            url: "/api/chat/get/all",
+            params: {
+                commonsId: commonsId,
+            }
+        },
+        { refetchInterval: refreshRate }
+    );
+  
+    const {
+      data: userCommonsList
+    } = useBackend(
+        ["/api/usercommons/all"],
+        {
+            method: "GET",
+            url: "/api/usercommons/all",
+            params: {
+                commonsId: commonsId,
+            }
+        },
+        { refetchInterval: refreshRate }
+    );
+
+    // Stryker restore all
+  
+    const userIdToUsername = Array.isArray(userCommonsList)
+    ? userCommonsList.reduce((acc, user) => {
+        acc[user.userId] = user.username || "";
+        return acc;
+        }, {})
+    : {};
+  
+    return (
+      <div style={{ overflowY: "scroll", maxHeight: "400px" }} aria-label="ChatDisplay" >
+        {Array.isArray(messages) && messages.slice(0, initialMessagePageSize).map((message) => (
+            <ChatMessageDisplay 
+                key={message.id} 
+                message={{ ...message, username: userIdToUsername[message.userId] }} 
+                testId={`ChatMessageDisplay-${message.id}`}
+            />
+        ))}
+      </div>
+    );
+};
+
+export default ChatDisplay;
+  

--- a/frontend/src/main/components/Chat/ChatDisplay.js
+++ b/frontend/src/main/components/Chat/ChatDisplay.js
@@ -2,51 +2,59 @@ import React from 'react';
 import ChatMessageDisplay from 'main/components/Chat/ChatMessageDisplay';
 import { useBackend } from "main/utils/useBackend";
 
-const ChatDisplay = ({ commonsId }) => {
+// Props for storybook manual injection
+
+const ChatDisplay = ({ commonsId, messages: messagesProp, userCommons: userCommonsListProp }) => {
     const initialMessagePageSize = 10;
     const refreshRate = 2000;
-    
-    // Stryker disable all
-    const {
-      data: messages
-    } = useBackend(
-        ["/api/chat/get"],
-        {
-            method: "GET",
-            url: "/api/chat/get/all",
-            params: {
-                commonsId: commonsId,
-            }
-        },
-        { refetchInterval: refreshRate }
-    );
-  
-    const {
-      data: userCommonsList
-    } = useBackend(
-        ["/api/usercommons/all"],
-        {
-            method: "GET",
-            url: "/api/usercommons/all",
-            params: {
-                commonsId: commonsId,
-            }
-        },
-        { refetchInterval: refreshRate }
-    );
 
-    // Stryker restore all
+    // Stryker disable all
+
+    const {
+        data: messagesData
+        } = useBackend(
+            ["/api/chat/get"],
+            {
+                method: "GET",
+                url: "/api/chat/get/all",
+                params: {
+                    commonsId: commonsId,
+                }
+            },
+            { refetchInterval: refreshRate }
+        );
   
+      const {
+        data: userCommonsListData
+        } = useBackend(
+            ["/api/usercommons/all"],
+            {
+                method: "GET",
+                url: "/api/usercommons/all",
+                params: {
+                    commonsId: commonsId,
+                }
+            },
+            { refetchInterval: refreshRate }
+      );
+      
+    // Stryker restore all
+
+    const messages = messagesProp || messagesData;
+    const userCommonsList = userCommonsListProp || userCommonsListData;
+  
+    const sortedMessages = Array.isArray(messages) && messages.sort((a, b) => a.id - b.id);
+
     const userIdToUsername = Array.isArray(userCommonsList)
     ? userCommonsList.reduce((acc, user) => {
         acc[user.userId] = user.username || "";
         return acc;
         }, {})
     : {};
-  
+
     return (
-      <div style={{ overflowY: "scroll", maxHeight: "400px" }} aria-label="ChatDisplay" >
-        {Array.isArray(messages) && messages.slice(0, initialMessagePageSize).map((message) => (
+      <div style={{ overflowY: "scroll", maxHeight: "400px" }} data-testid="ChatDisplay" >
+        {Array.isArray(sortedMessages) && sortedMessages.slice(0, initialMessagePageSize).map((message) => (
             <ChatMessageDisplay 
                 key={message.id} 
                 message={{ ...message, username: userIdToUsername[message.userId] }} 
@@ -58,4 +66,3 @@ const ChatDisplay = ({ commonsId }) => {
 };
 
 export default ChatDisplay;
-  

--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -1,0 +1,74 @@
+import React from "react";
+import { Button, Form, Row, Col } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { toast } from "react-toastify"
+
+import { useBackendMutation } from "main/utils/useBackend";
+
+const ChatMessageCreate = ({ commonsId, submitAction:submitProp }) => {
+
+    const testid = "ChatMessageCreate";
+
+    const objectToAxiosParams = (newMessage) => ({
+        url: "/api/chat/post",
+        method: "POST",
+        data: {message: newMessage.message, commonsId: commonsId}
+    });
+
+    const onSuccess = (chatMessage) => {
+        toast(<div>Message Sent!
+            <br />{`id: ${chatMessage.id}`}
+            <br />{`userId: ${chatMessage.userId}`}
+            <br />{`commonsId: ${chatMessage.commonsId}`}
+            <br />{`message: ${chatMessage.message}`}
+        </div>);
+    }
+   
+    // Stryker disable all
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/chat/get/all"]
+    );
+    // Stryker restore all
+
+    const submitAction = submitProp || (async (data) => {
+        mutation.mutate(data);
+    });
+
+    // Stryker disable all
+    const {
+        register,
+        formState: {errors},
+        handleSubmit,
+    } = useForm(
+        {defaultValues: {}}
+    );
+    // Stryker restore all
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+            <Row>
+                <Col sm={10}>
+                    <Form.Group className="mb-3">
+                        <Form.Control
+                            data-testid={`${testid}-Message`}
+                            id="message"
+                            type="text"
+                            {...register("message", { required: "Message cannot be empty" })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.message?.message}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col sm={2}>
+                    <Button type="submit" data-testid={`${testid}-Send`}>Send</Button>
+                </Col>
+            </Row>
+        </Form>
+    );
+};
+
+export default ChatMessageCreate;

--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -24,28 +24,22 @@ const ChatMessageCreate = ({ commonsId, submitAction:submitProp }) => {
         </div>);
     }
    
-    // Stryker disable all
     const mutation = useBackendMutation(
         objectToAxiosParams,
         { onSuccess },
         // Stryker disable next-line all : hard to set up test for caching
         ["/api/chat/get/all"]
     );
-    // Stryker restore all
 
     const submitAction = submitProp || (async (data) => {
         mutation.mutate(data);
     });
 
-    // Stryker disable all
     const {
         register,
         formState: {errors},
         handleSubmit,
-    } = useForm(
-        {defaultValues: {}}
-    );
-    // Stryker restore all
+    } = useForm( );
 
     return (
         <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -22,6 +22,7 @@ const ChatMessageCreate = ({ commonsId, submitAction:submitProp }) => {
             <br />{`commonsId: ${chatMessage.commonsId}`}
             <br />{`message: ${chatMessage.message}`}
         </div>);
+        reset();
     }
    
     const mutation = useBackendMutation(
@@ -39,6 +40,7 @@ const ChatMessageCreate = ({ commonsId, submitAction:submitProp }) => {
         register,
         formState: {errors},
         handleSubmit,
+        reset,
     } = useForm( );
 
     return (

--- a/frontend/src/main/components/Chat/ChatMessageDisplay.js
+++ b/frontend/src/main/components/Chat/ChatMessageDisplay.js
@@ -9,8 +9,8 @@ const ChatMessageDisplay = ({ message, testId }) => {
   }
 
   return (
-    <Card>
-      <Card.Body data-testid={testId} >
+    <Card data-testid={testId}>
+      <Card.Body>
         <Card.Title data-testid={`${testId}-User`}>{message.username} ({message.userId})</Card.Title>
         <Card.Subtitle data-testid={`${testId}-Date`}>{message.timestamp}</Card.Subtitle>
         <Card.Text data-testid={`${testId}-Message`}>{message.message}</Card.Text>

--- a/frontend/src/main/components/Chat/ChatMessageDisplay.js
+++ b/frontend/src/main/components/Chat/ChatMessageDisplay.js
@@ -1,0 +1,22 @@
+import { Card } from 'react-bootstrap';
+
+const ChatMessageDisplay = ({ message, testId }) => {
+  if (!message.username) {
+    message.username = "Anonymous";
+  }
+  if (message.timestamp) {
+    message.timestamp = message.timestamp.replace('T', ' ').split('.')[0];
+  }
+
+  return (
+    <Card>
+      <Card.Body data-testid={testId} >
+        <Card.Title data-testid={`${testId}-User`}>{message.username} ({message.userId})</Card.Title>
+        <Card.Subtitle data-testid={`${testId}-Date`}>{message.timestamp}</Card.Subtitle>
+        <Card.Text data-testid={`${testId}-Message`}>{message.message}</Card.Text>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default ChatMessageDisplay;

--- a/frontend/src/main/components/Chat/ChatMessageDisplay.js
+++ b/frontend/src/main/components/Chat/ChatMessageDisplay.js
@@ -11,8 +11,14 @@ const ChatMessageDisplay = ({ message, testId }) => {
   return (
     <Card data-testid={testId}>
       <Card.Body>
-        <Card.Title data-testid={`${testId}-User`}>{message.username} ({message.userId})</Card.Title>
-        <Card.Subtitle data-testid={`${testId}-Date`}>{message.timestamp}</Card.Subtitle>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Card.Title data-testid={`${testId}-User`} style={{ margin: 0 }}>
+            {message.username} ({message.userId})
+          </Card.Title>
+          <Card.Subtitle data-testid={`${testId}-Date`} style={{ margin: 0 }}>
+            {message.timestamp}
+          </Card.Subtitle>
+        </div>
         <Card.Text data-testid={`${testId}-Message`}>{message.message}</Card.Text>
       </Card.Body>
     </Card>

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.js
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ChatDisplay from 'main/components/Chat/ChatDisplay';
 import {chatMessageFixtures} from 'fixtures/chatMessageFixtures';
-import {userCommonsFixtures} from 'fixtures/userCommonsFixtures';
+import userCommonsFixtures from 'fixtures/userCommonsFixtures';
 
 export default {
     title: 'components/Chat/ChatDisplay',
@@ -19,7 +19,7 @@ export const Empty = Template.bind({});
 Empty.args = {
     commonsId: 1,
     messages: [],
-    userCommons: userCommonsFixtures.tenUserCommons
+    userCommons: userCommonsFixtures.threeUserCommons
 };
 
 export const OneMessage = Template.bind({});
@@ -27,7 +27,7 @@ export const OneMessage = Template.bind({});
 OneMessage.args = {
     commonsId: 1,
     messages: chatMessageFixtures.oneChatMessage,
-    userCommons: userCommonsFixtures.tenUserCommons
+    userCommons: userCommonsFixtures.oneUserCommons
 };
 
 export const ThreeMessages = Template.bind({});
@@ -35,5 +35,5 @@ export const ThreeMessages = Template.bind({});
 ThreeMessages.args = {
     commonsId: 1,
     messages: chatMessageFixtures.threeChatMessages,
-    userCommons: userCommonsFixtures.tenUserCommons
+    userCommons: userCommonsFixtures.threeUserCommons
 };

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.js
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import ChatDisplay from 'main/components/Chat/ChatDisplay';
+import {chatMessageFixtures} from 'fixtures/chatMessageFixtures';
+import {userCommonsFixtures} from 'fixtures/userCommonsFixtures';
+
+export default {
+    title: 'components/Chat/ChatDisplay',
+    component: ChatDisplay
+};
+
+const Template = (args) => {
+    return (
+        <ChatDisplay {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    commonsId: 1,
+    messages: [],
+    userCommons: userCommonsFixtures.tenUserCommons
+};
+
+export const OneMessage = Template.bind({});
+
+OneMessage.args = {
+    commonsId: 1,
+    messages: chatMessageFixtures.oneChatMessage,
+    userCommons: userCommonsFixtures.tenUserCommons
+};
+
+export const ThreeMessages = Template.bind({});
+
+ThreeMessages.args = {
+    commonsId: 1,
+    messages: chatMessageFixtures.threeChatMessages,
+    userCommons: userCommonsFixtures.tenUserCommons
+};

--- a/frontend/src/stories/components/Chat/ChatMessageDisplay.stories.js
+++ b/frontend/src/stories/components/Chat/ChatMessageDisplay.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import ChatMessageDisplay from 'main/components/Chat/ChatMessageDisplay';
+import { chatMessageFixtures } from 'fixtures/chatMessageFixtures';
+
+export default {
+    title: 'components/Chat/ChatMessageDisplay',
+    component: ChatMessageDisplay
+};
+
+const Template = (args) => {
+    return (
+        <ChatMessageDisplay {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    message: []
+};
+
+export const OneMessage = Template.bind({});
+
+OneMessage.args = {
+    message: {...chatMessageFixtures.oneChatMessage[0], username: "John Doe"}
+};
+
+export const OneMessageNoUser = Template.bind({});
+
+OneMessageNoUser.args = {
+    message: chatMessageFixtures.oneChatMessage[0]
+};
+

--- a/frontend/src/stories/components/Jobs/PagedJobsTable.stories.js
+++ b/frontend/src/stories/components/Jobs/PagedJobsTable.stories.js
@@ -4,7 +4,7 @@ import PagedJobsTable from "main/components/Jobs/PagedJobsTable";
 import jobsFixtures from "fixtures/jobsFixtures";
 
 export default {
-    title: 'components/Leaderboard/PagedJobsTable',
+    title: 'components/Jobs/PagedJobsTable',
     component: PagedJobsTable
 };
 

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.js
@@ -31,11 +31,11 @@ describe("ChatDisplay tests", () => {
     );
     
     await waitFor(() => {
-        expect(screen.getByLabelText("ChatDisplay")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatDisplay")).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText("ChatDisplay")).toHaveStyle("overflowY: scroll");
-    expect(screen.getByLabelText("ChatDisplay")).toHaveStyle("maxHeight: 400px");
+    expect(screen.getByTestId("ChatDisplay")).toHaveStyle("overflowY: scroll");
+    expect(screen.getByTestId("ChatDisplay")).toHaveStyle("maxHeight: 400px");
 
   });
 
@@ -77,7 +77,7 @@ describe("ChatDisplay tests", () => {
 
   });
 
-  test("displays three messages correctly with usernames", async () => {
+  test("displays three messages correctly with usernames in the correct order", async () => {
 
     //arrange
 
@@ -106,12 +106,14 @@ describe("ChatDisplay tests", () => {
     expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
     expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
 
-    await waitFor(() => {
-        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
-        expect(screen.getByTestId("ChatMessageDisplay-2")).toBeInTheDocument();
-        expect(screen.getByTestId("ChatMessageDisplay-3")).toBeInTheDocument();
+    const container = screen.getByTestId("ChatDisplay");
 
+    await waitFor(() => {
+        expect(container.children[0].getAttribute("data-testid")).toBe("ChatMessageDisplay-1");
+        expect(container.children[1].getAttribute("data-testid")).toBe("ChatMessageDisplay-2");
+        expect(container.children[2].getAttribute("data-testid")).toBe("ChatMessageDisplay-3");
     });
+
     expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("George Washington (1)");
     expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
     expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent("2023-08-17 23:57:46");

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.js
@@ -108,11 +108,15 @@ describe("ChatDisplay tests", () => {
 
     const container = screen.getByTestId("ChatDisplay");
 
+    /* eslint-disable testing-library/no-node-access */
+
     await waitFor(() => {
         expect(container.children[0].getAttribute("data-testid")).toBe("ChatMessageDisplay-1");
-        expect(container.children[1].getAttribute("data-testid")).toBe("ChatMessageDisplay-2");
-        expect(container.children[2].getAttribute("data-testid")).toBe("ChatMessageDisplay-3");
     });
+    expect(container.children[1].getAttribute("data-testid")).toBe("ChatMessageDisplay-2");
+    expect(container.children[2].getAttribute("data-testid")).toBe("ChatMessageDisplay-3");
+
+    /* eslint-enable testing-library/no-node-access */
 
     expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("George Washington (1)");
     expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
@@ -237,9 +241,11 @@ describe("ChatDisplay tests", () => {
 
     await waitFor(() => {
         expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
-        expect(screen.getByTestId("ChatMessageDisplay-2")).toBeInTheDocument();
-        expect(screen.getByTestId("ChatMessageDisplay-10")).toBeInTheDocument();
+        
     });
+
+    expect(screen.getByTestId("ChatMessageDisplay-2")).toBeInTheDocument();
+    expect(screen.getByTestId("ChatMessageDisplay-10")).toBeInTheDocument();
 
     expect(screen.queryByTestId("ChatMessageDisplay-11")).not.toBeInTheDocument();
     expect(screen.queryByTestId("ChatMessageDisplay-12")).not.toBeInTheDocument();

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.js
@@ -1,0 +1,251 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import ChatDisplay from "main/components/Chat/ChatDisplay";
+import userCommonsFixtures from "fixtures/userCommonsFixtures";
+import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ChatDisplay tests", () => {
+  const queryClient = new QueryClient();
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const commonsId = 1;
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+  test("renders without crashing", async () => {
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    await waitFor(() => {
+        expect(screen.getByLabelText("ChatDisplay")).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("ChatDisplay")).toHaveStyle("overflowY: scroll");
+    expect(screen.getByLabelText("ChatDisplay")).toHaveStyle("maxHeight: 400px");
+
+  });
+
+  test("displays one message correctly with username", async () => {
+
+    //arrange
+
+    axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.oneChatMessage);
+    axiosMock.onGet("/api/usercommons/all").reply(200, userCommonsFixtures.oneUserCommons);
+
+    //act
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    //assert
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(axiosMock.history.get[0].url).toBe("/api/chat/get/all");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBe(2);
+    });
+    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("George Washington (1)")).toBeInTheDocument();
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+    expect(screen.getByText("2023-08-17 23:57:46")).toBeInTheDocument();
+
+  });
+
+  test("displays three messages correctly with usernames", async () => {
+
+    //arrange
+
+    axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.threeChatMessages);
+    axiosMock.onGet("/api/usercommons/all").reply(200, userCommonsFixtures.threeUserCommons);
+
+    //act
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    //assert
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(axiosMock.history.get[0].url).toBe("/api/chat/get/all");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBe(2);
+    });
+    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageDisplay-2")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageDisplay-3")).toBeInTheDocument();
+
+    });
+    expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("George Washington (1)");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent("2023-08-17 23:57:46");
+
+    expect(screen.getByTestId("ChatMessageDisplay-2-User")).toHaveTextContent("Thomas Jefferson (3)");
+    expect(screen.getByTestId("ChatMessageDisplay-2-Message")).toHaveTextContent("Hello World How are you doing???");
+    expect(screen.getByTestId("ChatMessageDisplay-2-Date")).toHaveTextContent("2023-08-18 02:59:11");
+
+    expect(screen.getByTestId("ChatMessageDisplay-3-User")).toHaveTextContent("John Adams (2)");
+    expect(screen.getByTestId("ChatMessageDisplay-3-Message")).toHaveTextContent("This is another test for chat messaging");
+    expect(screen.getByTestId("ChatMessageDisplay-3-Date")).toHaveTextContent("2023-08-18 02:59:28");
+
+  });
+
+  test("displays one message correctly without users", async () => {
+
+    //arrange
+
+    axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.threeChatMessages);
+    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+
+    //act
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    //assert
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(axiosMock.history.get[0].url).toBe("/api/chat/get/all");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBe(2);
+    });
+    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
+
+    });
+    expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("Anonymous (1)");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent("2023-08-17 23:57:46");
+
+  });
+
+  test("displays one message correctly without usernames", async () => {
+
+    //arrange
+
+    axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.threeChatMessages);
+    axiosMock.onGet("/api/usercommons/all").reply(200, [{userId: 1}]);
+
+    //act
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    //assert
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(axiosMock.history.get[0].url).toBe("/api/chat/get/all");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBe(2);
+    });
+    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
+
+    });
+    expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("Anonymous (1)");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent("2023-08-17 23:57:46");
+
+  });
+
+  test("displays cuts off at 10 messages", async () => {
+
+    //arrange
+
+    axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.twelveChatMessages);
+    axiosMock.onGet("/api/usercommons/all").reply(200, userCommonsFixtures.threeUserCommons);
+
+    //act
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <ChatDisplay commonsId={commonsId} />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+    
+    //assert
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(axiosMock.history.get[0].url).toBe("/api/chat/get/all");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(axiosMock.history.get.length).toBe(2);
+    });
+    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/all");
+    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
+
+    await waitFor(() => {
+        expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageDisplay-2")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageDisplay-10")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("ChatMessageDisplay-11")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ChatMessageDisplay-12")).not.toBeInTheDocument();
+    
+    expect(screen.queryByText("This should not appear")).not.toBeInTheDocument();
+    expect(screen.queryByText("This should also be cut off")).not.toBeInTheDocument();
+
+
+  });
+
+});

--- a/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
@@ -1,0 +1,144 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import ChatMessageCreate from "main/components/Chat/ChatMessageCreate";
+import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import AxiosMockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("ChatMessageCreate", () => {
+    const commonsId = 1;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/chat/get/all").reply(200, chatMessageFixtures.oneChatMessage[0]);
+    });
+
+    test("renders without crashing", async () => {
+        // arrange
+        const submitAction = jest.fn();
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        //assert
+
+        await waitFor(() => {
+            expect(screen.getByText(/Send/)).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId("ChatMessageCreate-Message")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageCreate-Send")).toBeInTheDocument();
+
+    });
+
+    test("shows an error when the message input is empty", async () => {
+        // arrange
+        const submitAction = jest.fn();
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        //assert
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+
+        fireEvent.click(sendButton);
+
+        await waitFor(() => {
+            expect(screen.getByText("Message cannot be empty")).toBeInTheDocument();
+        });
+    });
+
+    test("calls the correct submit action on successful submission", async () => {
+        // arrange
+        const submitAction = jest.fn();
+        const messageText = "Hello, World!";
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        const messageInput = screen.getByTestId("ChatMessageCreate-Message");
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+
+        fireEvent.change(messageInput, {target: {value: messageText}});
+        fireEvent.click(sendButton);
+
+        // Wait for submit action to be called
+        await waitFor(() => {
+            expect(submitAction).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    test("When you fill in the message form and click submit, the right things happen", async () => {
+
+        const messageText = "Hello World";
+        const expectedMessage = {
+            message: messageText,
+            commonsId: commonsId,
+        };
+    
+        axiosMock.onPost("/api/chat/post").reply(200, {
+            message: messageText,
+            commonsId: commonsId,
+            id: 1,
+            userId: 1
+        } );
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate commonsId={commonsId} />
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Send/)).toBeInTheDocument();
+        });
+    
+        const messageInput = screen.getByTestId("ChatMessageCreate-Message");
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+    
+        fireEvent.change(messageInput, { target: { value: messageText } });
+        fireEvent.click(sendButton);
+    
+        await waitFor(() => 
+            expect(axiosMock.history.post.length).toBe(1)
+        );
+    
+        expect(axiosMock.history.post[0].data).toEqual(JSON.stringify(expectedMessage));
+
+        expect(mockToast).toHaveBeenCalledWith(<div>Message Sent!
+            <br />{`id: 1`}
+            <br />{`userId: 1`}
+            <br />{`commonsId: 1`}
+            <br />{`message: Hello World`}
+        </div>);
+    
+    });
+    
+});

--- a/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
@@ -103,12 +103,7 @@ describe("ChatMessageCreate", () => {
             commonsId: commonsId,
         };
     
-        axiosMock.onPost("/api/chat/post").reply(200, {
-            message: messageText,
-            commonsId: commonsId,
-            id: 1,
-            userId: 1
-        } );
+        axiosMock.onPost("/api/chat/post").reply(200, chatMessageFixtures.oneChatMessage[0] );
     
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
@@ -133,6 +133,8 @@ describe("ChatMessageCreate", () => {
             <br />{`commonsId: 1`}
             <br />{`message: Hello World`}
         </div>);
+
+        expect(messageInput.value).toEqual("");
     
     });
     

--- a/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
@@ -13,7 +13,7 @@ describe("ChatMessageDisplay tests", () => {
 
         // act
         render(
-            <ChatMessageDisplay message={message} />
+            <ChatMessageDisplay testId="ChatMessageDisplay-1" message={message} />
         );
 
         // assert
@@ -23,6 +23,12 @@ describe("ChatMessageDisplay tests", () => {
 
         expect(screen.getByText("John Doe (1)")).toBeInTheDocument();
         expect(screen.getByText("2023-08-17 23:57:46")).toBeInTheDocument();
+
+        const styleDiv = screen.getByTestId("ChatMessageDisplay-1-User").parentElement;
+
+        expect(styleDiv).toHaveStyle("display: flex; justify-content: space-between; align-items: center");
+        expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveStyle("margin: 0px");
+        expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveStyle("margin: 0px");
     });
 
     test("renders correct content with empty username", async () => {

--- a/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
@@ -1,0 +1,67 @@
+import ChatMessageDisplay from "main/components/Chat/ChatMessageDisplay";
+
+import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
+import { render, screen, waitFor } from "@testing-library/react";
+
+describe("ChatMessageDisplay tests", () => {
+
+    test("renders correct content with username", async () => {
+
+        const message_no_name = chatMessageFixtures.oneChatMessage[0];
+
+        const message = {...message_no_name, username: "John Doe"};
+
+        // act
+        render(
+            <ChatMessageDisplay message={message} />
+        );
+
+        // assert
+        await waitFor(() => {
+            expect(screen.getByText("Hello World")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("John Doe (1)")).toBeInTheDocument();
+        expect(screen.getByText("2023-08-17 23:57:46")).toBeInTheDocument();
+    });
+
+    test("renders correct content with empty username", async () => {
+
+        const message_no_name = chatMessageFixtures.oneChatMessage[0];
+
+        const message = {...message_no_name, username: ""};
+
+        // act
+        render(
+            <ChatMessageDisplay message={message} />
+        );
+
+        // assert
+        await waitFor(() => {
+            expect(screen.getByText("Hello World")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Anonymous (1)")).toBeInTheDocument();
+        expect(screen.getByText("2023-08-17 23:57:46")).toBeInTheDocument();
+    });
+
+    test("renders correct content with no timestamp or username", async () => {
+
+        const message_no_name = chatMessageFixtures.oneChatMessage[0];
+        message_no_name.timestamp = null;
+
+        // act
+        render(
+            <ChatMessageDisplay testId="ChatMessageDisplay-1" message={message_no_name} />
+        );
+
+        // assert
+        await waitFor(() => {
+            expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent("Hello World");
+        });
+
+        expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent("Anonymous (1)");
+        expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent("");
+    });
+
+});

--- a/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageDisplay.test.js
@@ -24,6 +24,7 @@ describe("ChatMessageDisplay tests", () => {
         expect(screen.getByText("John Doe (1)")).toBeInTheDocument();
         expect(screen.getByText("2023-08-17 23:57:46")).toBeInTheDocument();
 
+        /* eslint-disable-next-line testing-library/no-node-access */
         const styleDiv = screen.getByTestId("ChatMessageDisplay-1-User").parentElement;
 
         expect(styleDiv).toHaveStyle("display: flex; justify-content: space-between; align-items: center");

--- a/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
@@ -1,18 +1,11 @@
 package edu.ucsb.cs156.happiercows.config;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +22,6 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
@@ -3,20 +3,16 @@ package edu.ucsb.cs156.happiercows.controllers;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.errors.NoCowsException;
 import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 
-// import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.models.CurrentUser;
 import edu.ucsb.cs156.happiercows.services.CurrentUserService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.Map;
 
-@Slf4j
 public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageController.java
@@ -1,0 +1,118 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+import edu.ucsb.cs156.happiercows.repositories.ChatMessageRepository;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+import java.util.Optional;
+
+@Tag(name = "Chat Message")
+@RequestMapping("/api/chat")
+@RestController
+public class ChatMessageController extends ApiController{
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary = "Get all chat messages", description = "Get all chat messages associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public ResponseEntity<Object> getAllChatMessages(@Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                            @Parameter(name="page") @RequestParam int page,
+                                            @Parameter(name="size") @RequestParam int size) {
+        
+        // Make sure the user is part of the commons or is an admin
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+        Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+        if (!userCommonsLookup.isPresent() && !u.isAdmin()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Return the list of non-hidden chat messages
+        Page<ChatMessage> messages = chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        return ResponseEntity.ok(messages);
+    }
+
+    @Operation(summary = "Get all chat messages", description = "Get all chat messages associated with a specific commons, even the hidden ones")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/get/all")
+    public ResponseEntity<Object> getAllChatMessages(@Parameter(description = "The id of the common") @RequestParam Long commonsId) {
+        
+        // Return the list of chat messages
+        Iterable<ChatMessage> messages = chatMessageRepository.findAllByCommonsId(commonsId);
+        return ResponseEntity.ok(messages);
+    }
+
+    @Operation(summary = "Create a chat message", description = "Create a chat message associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public ResponseEntity<Object> createChatMessage(@Parameter(description = "The id of the common") @RequestParam Long commonsId,
+                                                    @Parameter(description = "The message to be sent") @RequestParam String content) {
+        
+        // Make sure the user is part of the commons
+        User u = getCurrentUser().getUser();
+        Long userId = u.getId();
+        Optional<UserCommons> userCommonsLookup = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId);
+
+        if (!userCommonsLookup.isPresent() && !u.isAdmin()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        // Create the chat message
+        ChatMessage chatMessage = ChatMessage.builder()
+        .commonsId(commonsId)
+        .userId(userId)
+        .message(content)
+        .hidden(false)
+        .dm(false)
+        .toUserId(0)
+        .build();
+
+        return ResponseEntity.ok(chatMessage);
+    }
+
+    @Operation(summary = "Delete a chat message", description = "Delete a chat message associated with a specific commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public ResponseEntity<Object> deleteChatMessage(@Parameter(description = "The id of the chat message") @RequestParam Long chatMessageId) {
+        
+        // Delete the chat message
+        Optional<ChatMessage> chatMessageLookup = chatMessageRepository.findById(chatMessageId);
+        if (!chatMessageLookup.isPresent()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        ChatMessage chatMessage = chatMessageLookup.get();
+        chatMessage.setHidden(true);
+        chatMessageRepository.save(chatMessage);
+
+        return ResponseEntity.ok(chatMessage);
+    }
+
+    
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -9,7 +9,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,8 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
 @RestController
-@Slf4j
-
 public class ProfitsController extends ApiController {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ReportsController.java
@@ -1,20 +1,15 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import edu.ucsb.cs156.happiercows.entities.Profit;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.ReportLine;
-import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.helpers.ReportCSVHelper;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.ReportLineRepository;
 import edu.ucsb.cs156.happiercows.repositories.ReportRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.http.HttpHeaders;
@@ -26,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.catalina.session.FileStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/SystemInfoController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -25,7 +25,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import org.springframework.http.ResponseEntity;
+import javax.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User Commons")
 @RequestMapping("/api/usercommons")
@@ -41,8 +45,8 @@ public class UserCommonsController extends ApiController {
   @Autowired
   ObjectMapper mapper;
 
-  @Operation(summary = "Get a specific user commons")
-  @PreAuthorize("hasRole('ROLE_USER')")
+  @Operation(summary = "Get a specific user commons (admin only)")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
   @GetMapping("")
   public UserCommons getUserCommonsById(
       @Parameter(name="userId") @RequestParam Long userId,

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -41,8 +41,8 @@ public class UserCommonsController extends ApiController {
   @Autowired
   ObjectMapper mapper;
 
-  @Operation(summary = "Get a specific user commons (admin only)")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @Operation(summary = "Get a specific user commons")
+  @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("")
   public UserCommons getUserCommonsById(
       @Parameter(name="userId") @RequestParam Long userId,

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -25,11 +25,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import org.springframework.http.ResponseEntity;
-import javax.validation.Valid;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User Commons")
 @RequestMapping("/api/usercommons")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserInfoController.java
@@ -1,8 +1,6 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.models.CurrentUser;
-import edu.ucsb.cs156.happiercows.services.CurrentUserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/ChatMessage.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/ChatMessage.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import org.hibernate.annotations.CreationTimestamp;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "chat_message")
+public class ChatMessage {
+    
+    // Unique Message Id
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    // The user that created this message and the commons that it belongs in
+    private long userId;
+    private long commonsId;
+
+    // Message timestamp and payload
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date timestamp;
+    private String message;
+
+    // For future use in DMs
+    private boolean dm;
+    private long toUserId;
+
+    // We do not delete messages in the backend, we just hide them
+    @Builder.Default
+    private boolean hidden = false;
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/ReportLine.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.happiercows.entities;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 
 import javax.persistence.*;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import javax.persistence.*;

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
@@ -9,8 +9,6 @@ import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import edu.ucsb.cs156.happiercows.entities.ReportLine;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 /*
  * This code is based on 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobFactory.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.happiercows.jobs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -5,9 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
 import lombok.AccessLevel;
-import org.springframework.beans.factory.annotation.Value;
-
-
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
@@ -18,5 +20,5 @@ public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")
-    ChatMessage findById(long id);
+    Optional<ChatMessage> findById(long id);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -13,10 +13,10 @@ import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false", nativeQuery = true)
     Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
 
-    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId", nativeQuery = true)
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+
+@Repository
+public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -11,10 +11,10 @@ import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false", nativeQuery = true)
     Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
 
-    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId")
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId", nativeQuery = true)
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -1,11 +1,22 @@
 package edu.ucsb.cs156.happiercows.repositories;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    
+    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
+    Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
+
+    @Query("SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId")
+    Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
+
+    @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")
+    ChatMessage findById(long id);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ChatMessageRepository.java
@@ -13,10 +13,10 @@ import edu.ucsb.cs156.happiercows.entities.ChatMessage;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long>{
-    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false", nativeQuery = true)
+    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId AND cm.hidden = false")
     Page<ChatMessage> findByCommonsId(Long commonsId, Pageable pageable);
 
-    @Query(value = "SELECT * FROM chat_message cm WHERE cm.commonsId = :commonsId", nativeQuery = true)
+    @Query(value = "SELECT cm FROM chat_message cm WHERE cm.commonsId = :commonsId")
     Iterable<ChatMessage> findAllByCommonsId(Long commonsId);
 
     @Query("SELECT cm FROM chat_message cm WHERE cm.id = :id")

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
@@ -308,4 +308,24 @@ public class ChatMessageControllerTests extends ControllerTestCase {
         assertEquals(expectedResponseString, responseString);
     }
 
+    // Cannot delete chat messages that don't exist
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCannotDeleteChatMessagesThatDontExist() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        //act 
+        mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findById(messageId);
+        verify(chatMessageRepository, times(0)).save(any(ChatMessage.class));
+    }
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ChatMessageControllerTests.java
@@ -1,0 +1,311 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.repositories.ChatMessageRepository;
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = ChatMessageController.class)
+@Import(ChatMessageController.class)
+@AutoConfigureDataJpa
+public class ChatMessageControllerTests extends ControllerTestCase {
+    
+    @MockBean
+    ChatMessageRepository chatMessageRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanGetAllChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).build();
+
+        Iterable<ChatMessage> iterableOfChatMessages = Arrays.asList(chatMessage1, chatMessage2);
+
+        when(chatMessageRepository.findAllByCommonsId(commonsId)).thenReturn(iterableOfChatMessages);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get/all?commonsId={commonsId}", commonsId))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findAllByCommonsId(commonsId);
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(iterableOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCannotUseGetAllAPIEndpoint() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).build();
+
+        Iterable<ChatMessage> iterableOfChatMessages = Arrays.asList(chatMessage1, chatMessage2);
+
+        when(chatMessageRepository.findAllByCommonsId(commonsId)).thenReturn(iterableOfChatMessages);
+
+        // act
+        mockMvc.perform(get("/api/chat/get/all?commonsId={commonsId}", commonsId))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).findAllByCommonsId(commonsId);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(pageOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        // act
+        mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isForbidden()).andReturn();
+        
+        // assert
+        verify(chatMessageRepository, times(0)).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        UserCommons userCommons = UserCommons.builder().build();
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.of(userCommons));
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+    
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userNotInCommonsCannotPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        when(userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)).thenReturn(Optional.empty());
+
+        //act 
+        mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).save(any(ChatMessage.class));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userCannotDeleteChatMessages() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        //act 
+        mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isForbidden()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, times(0)).delete(any(ChatMessage.class));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanDeleteChatMessages() throws Exception {
+        
+        // arrange
+        Long messageId = 0L;
+
+        ChatMessage chatMessage = ChatMessage.builder().id(messageId).build();
+        when(chatMessageRepository.findById(messageId)).thenReturn(Optional.of(chatMessage));
+
+        //act 
+        MvcResult response = mockMvc.perform(delete("/api/chat/delete?chatMessageId={messageId}", messageId).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findById(messageId);
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        chatMessage.setHidden(true);
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanGetChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        int page = 0;
+        int size = 10;
+
+        ChatMessage chatMessage1 = ChatMessage.builder().id(1L).commonsId(commonsId).userId(userId).build();
+        ChatMessage chatMessage2 = ChatMessage.builder().id(2L).commonsId(commonsId).userId(userId).build();
+
+        Page<ChatMessage> pageOfChatMessages = new PageImpl<ChatMessage>(Arrays.asList(chatMessage1, chatMessage2));
+
+        when(chatMessageRepository.findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()))).thenReturn(pageOfChatMessages);
+        
+        // act
+        MvcResult response = mockMvc.perform(get("/api/chat/get?commonsId={commonsId}&page={page}&size={size}", commonsId, page, size))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).findByCommonsId(commonsId, PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(pageOfChatMessages);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanPostChatMessages() throws Exception {
+        
+        // arrange
+        Long commonsId = 1L;
+        Long userId = 1L;
+        String content = "Hello world!";
+
+        ChatMessage chatMessage = ChatMessage.builder().id(0L).commonsId(commonsId).userId(userId).message(content).build();
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(chatMessage);
+        
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/chat/post?commonsId={commonsId}&content={content}", commonsId, content).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(chatMessage);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ReportsControllerTests.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,42 +58,6 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .build();
     }
 
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void test_getUserCommonsById_exists_admin() throws Exception {
-
-        UserCommons expectedUserCommons = getTestUserCommons();
-        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(expectedUserCommons));
-
-        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
-                .andExpect(status().isOk()).andReturn();
-
-        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-
-        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-        String responseString = response.getResponse().getContentAsString();
-
-        assertEquals(expectedJson, responseString);
-    }
-
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void test_getUserCommonsById_nonexists_admin() throws Exception {
-
-        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.empty());
-
-        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
-                .andExpect(status().is(404)).andReturn();
-
-        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-
-        String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-
-        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-        Map<String, Object> jsonResponse = responseToJson(response);
-        assertEquals(expectedJson, jsonResponse);
-    }
-
     @WithMockUser(roles = {"USER"})
     @Test
     public void test_getUserCommonsById_exists() throws Exception {
@@ -101,7 +65,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         UserCommons expectedUserCommons = getTestUserCommons();
         when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(expectedUserCommons));
 
-        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
                 .andExpect(status().isOk()).andReturn();
 
         verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
@@ -118,13 +82,13 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
         when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.empty());
 
-        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
                 .andExpect(status().is(404)).andReturn();
 
         verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
 
-        String responseString = response.getResponse().getContentAsString();
         String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,6 +58,42 @@ public class UserCommonsControllerTests extends ControllerTestCase {
                 .build();
     }
 
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void test_getUserCommonsById_exists_admin() throws Exception {
+
+        UserCommons expectedUserCommons = getTestUserCommons();
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(expectedUserCommons));
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void test_getUserCommonsById_nonexists_admin() throws Exception {
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+                .andExpect(status().is(404)).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+
+        String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
     @WithMockUser(roles = {"USER"})
     @Test
     public void test_getUserCommonsById_exists() throws Exception {
@@ -65,7 +101,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         UserCommons expectedUserCommons = getTestUserCommons();
         when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(expectedUserCommons));
 
-        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
                 .andExpect(status().isOk()).andReturn();
 
         verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
@@ -82,13 +118,13 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
         when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.empty());
 
-        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
                 .andExpect(status().is(404)).andReturn();
 
         verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
 
+        String responseString = response.getResponse().getContentAsString();
         String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-
         Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
         Map<String, Object> jsonResponse = responseToJson(response);
         assertEquals(expectedJson, jsonResponse);

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
@@ -2,8 +2,6 @@ package edu.ucsb.cs156.happiercows.entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import edu.ucsb.cs156.happiercows.entities.User;
-
 import org.junit.jupiter.api.Test;
 
 public class UserTests {

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobFactoryTests.java
@@ -10,9 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 
 @RestClientTest(InstructorReportJobFactory.class)

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobSingleCommonsTests.java
@@ -4,20 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
-import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.services.ReportService;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJobTests.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -1,7 +1,5 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,22 +9,12 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-
-// @Slf4j
-// @ExtendWith(SpringExtension.class)
-// @ContextConfiguration 
 
 @RestClientTest(ScheduledJobs.class)
 @AutoConfigureDataJpa

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/TestJobTests.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +11,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Slf4j
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration 
 public class TestJobTests {

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -2,23 +2,12 @@ package edu.ucsb.cs156.happiercows.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
-
-
-import javax.persistence.Column;
-import javax.persistence.Enumerated;
-import javax.persistence.TemporalType;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-
-import edu.ucsb.cs156.happiercows.ControllerTestCase;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Report;

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -1,14 +1,10 @@
 package edu.ucsb.cs156.happiercows.services;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;

--- a/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
@@ -2,24 +2,13 @@ package edu.ucsb.cs156.happiercows.testconfig;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.happiercows.entities.User;
-import edu.ucsb.cs156.happiercows.models.CurrentUser;
-import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.CurrentUserServiceImpl;
 
 @Slf4j


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we implement the ChatMessageCreate component for the chat frontend. The component contains a form with a message field that clears after a message is sent.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/73aaab48-5341-4196-996a-66881e1836b1)
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/d211da47-0bbb-4838-8b83-dff0e8b2324a)

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #74 
