### PR TITLE
Backend API endpoint for paged profits

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -11,11 +11,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
@@ -47,5 +54,34 @@ public class ProfitsController extends ApiController {
         Iterable<Profit> profits = profitRepository.findAllByUserCommons(userCommons);
 
         return profits;
+    }
+
+    @Operation(summary = "Get all profits belonging to a user commons as a user via CommonsID with pagination")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/paged/commonsid")
+    public Page<Profit> allProfitsByCommonsIdWithPagination(
+            @Parameter(name = "commonsId") @RequestParam Long commonsId,
+            @Parameter(name = "pageNumber", description = "Page number, 0 indexed") @RequestParam(defaultValue = "0") int pageNumber,
+            @Parameter(name = "pageSize", description = "Number of records per page") @RequestParam(defaultValue = "7") int pageSize
+
+    ) {
+        Long userId = getCurrentUser().getUser().getId();
+
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+        Iterable<Profit> iterableProfits = profitRepository.findAllByUserCommons(userCommons);
+
+        List<Profit> allProfits = new ArrayList<>();
+        iterableProfits.forEach(allProfits::add);
+
+        int start = pageNumber * pageSize;
+        int end = Math.min((start + pageSize), allProfits.size());
+        List<Profit> paginatedProfits = allProfits.subList(start, end);
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Page<Profit> profitsPage = new PageImpl<>(paginatedProfits, pageable, allProfits.size());
+
+        return profitsPage;
     }
 }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added an additional API endpoint for paged profits. This API endpoint prepares for the pagination feature.
API end point located at ```/api/profits/paged/commonsid``` has 3 parameters. One parameter is required: commonid. Default values for page number and page size are 0 and 7. 

Sample API endpoint: 
```
/api/profits/paged/commonsid?commonsId=1&page=0&size=7
```

## Screenshots 
Swagger

![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/68430949/302d0a87-588f-4678-9352-e2dd186a5539)

## Tests
Backend Test coverage & Mutation 100%. 

## Linked Issues
Closes #65 
Backend part of #6 
