### PR TITLE
Create a demo play page for visitors

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,8 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 
+import DemoPlayPage from "main/pages/DemoPlayPage";
+
 function App() {
 
   const { data: currentUser } = useCurrentUser();
@@ -53,6 +55,7 @@ function App() {
            </>
           )
         }
+        <Route path="/demo/play" element={<DemoPlayPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/assets/UserHomeDummy.json
+++ b/frontend/src/assets/UserHomeDummy.json
@@ -7,9 +7,9 @@
 
   "SessionInfo": {
     "username": "Visitor",
-    "totalWealth": 500.5,
+    "totalWealth": 5564500000,
     "numOfCows": 10,
-    "cowHealth": 0.5,
+    "cowHealth": 20.5,
     "cowsBought": 10,
     "cowsSold": 0,
     "cowDeaths": 0,

--- a/frontend/src/assets/UserHomeDummy.json
+++ b/frontend/src/assets/UserHomeDummy.json
@@ -1,0 +1,345 @@
+{
+  "commonid" : 0,
+  "UserInfo": {
+    "loggedIn": false,
+    "root": {}
+  },
+
+  "SessionInfo": {
+    "username": "Visitor",
+    "totalWealth": 500.5,
+    "numOfCows": 10,
+    "cowHealth": 0.5,
+    "cowsBought": 10,
+    "cowsSold": 0,
+    "cowDeaths": 0,
+    "userId": 0,
+    "commonsId": 0
+  },
+
+  "SessionInfo2": {
+    "commons": {
+      "id": 0,
+      "name": "Visitor Common",
+      "cowPrice": 1500,
+      "milkPrice": 5,
+      "startingBalance": 100,
+      "startingDate": "2023-08-10T07:00:00",
+      "showLeaderboard": true,
+      "carryingCapacity": 500,
+      "degradationRate": 0.1,
+      "belowCapacityHealthUpdateStrategy": "Constant",
+      "aboveCapacityHealthUpdateStrategy": "Linear"
+    },
+    "totalCows": 10,
+    "totalUsers": 1
+  },
+
+
+
+  "Transactions":[
+    {
+      "id": 11,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 1150,
+      "timestamp": "2023-08-15T04:00:00.046697",
+      "numCows": 23,
+      "avgCowHealth": 100
+    },
+    {
+      "id": 14,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 575,
+      "timestamp": "2023-08-16T02:56:32.332651",
+      "numCows": 23,
+      "avgCowHealth": 50
+    },
+    {
+      "id": 19,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 3.45,
+      "timestamp": "2023-08-16T04:00:00.060382",
+      "numCows": 23,
+      "avgCowHealth": 0.3
+    },
+    {
+      "id": 24,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 5.75,
+      "timestamp": "2023-08-17T04:00:00.166537",
+      "numCows": 23,
+      "avgCowHealth": 0.5
+    },
+    {
+      "id": 29,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 8.049999999999999,
+      "timestamp": "2023-08-18T04:00:00.13798",
+      "numCows": 23,
+      "avgCowHealth": 0.7
+    },
+    {
+      "id": 33,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 10.35,
+      "timestamp": "2023-08-19T04:00:00.059692",
+      "numCows": 23,
+      "avgCowHealth": 0.8999999999999999
+    },
+    {
+      "id": 39,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 12.65,
+      "timestamp": "2023-08-20T04:00:00.097756",
+      "numCows": 23,
+      "avgCowHealth": 1.0999999999999999
+    },
+    {
+      "id": 44,
+      "userCommons": {
+        "username": "Visitor",
+        "totalWealth": 500.5,
+        "numOfCows": 10,
+        "cowHealth": 0.5,
+        "cowsBought": 10,
+        "cowsSold": 0,
+        "cowDeaths": 0,
+        "userId": 0,
+        "commonsId": 0
+      },
+      "amount": 14.950000000000003,
+      "timestamp": "2023-08-21T04:00:00.088256",
+      "numCows": 23,
+      "avgCowHealth": 1.3
+    }
+  ],
+
+
+  "PagedTransactions":{
+    "content": [
+      {
+        "id": 11,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 1150,
+        "timestamp": "2023-08-15T04:00:00.046697",
+        "numCows": 23,
+        "avgCowHealth": 100
+      },
+      {
+        "id": 14,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 575,
+        "timestamp": "2023-08-16T02:56:32.332651",
+        "numCows": 23,
+        "avgCowHealth": 50
+      },
+      {
+        "id": 19,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 3.45,
+        "timestamp": "2023-08-16T04:00:00.060382",
+        "numCows": 23,
+        "avgCowHealth": 0.3
+      },
+      {
+        "id": 24,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 5.75,
+        "timestamp": "2023-08-17T04:00:00.166537",
+        "numCows": 23,
+        "avgCowHealth": 0.5
+      },
+      {
+        "id": 29,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 8.049999999999999,
+        "timestamp": "2023-08-18T04:00:00.13798",
+        "numCows": 23,
+        "avgCowHealth": 0.7
+      },
+      {
+        "id": 33,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 10.35,
+        "timestamp": "2023-08-19T04:00:00.059692",
+        "numCows": 23,
+        "avgCowHealth": 0.8999999999999999
+      },
+      {
+        "id": 39,
+        "userCommons": {
+          "username": "Visitor",
+          "totalWealth": 500.5,
+          "numOfCows": 10,
+          "cowHealth": 0.5,
+          "cowsBought": 10,
+          "cowsSold": 0,
+          "cowDeaths": 0,
+          "userId": 0,
+          "commonsId": 0
+        },
+        "amount": 12.65,
+        "timestamp": "2023-08-20T04:00:00.097756",
+        "numCows": 23,
+        "avgCowHealth": 1.0999999999999999
+      }
+    ],
+    "pageable": {
+      "sort": {
+        "sorted": false,
+        "empty": true,
+        "unsorted": true
+      },
+      "pageNumber": 0,
+      "pageSize": 7,
+      "offset": 0,
+      "paged": true,
+      "unpaged": false
+    },
+    "last": false,
+    "totalPages": 2,
+    "totalElements": 8,
+    "first": true,
+    "sort": {
+      "sorted": false,
+      "empty": true,
+      "unsorted": true
+    },
+    "size": 7,
+    "number": 0,
+    "numberOfElements": 7,
+    "empty": false
+  }
+
+
+}

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -3,12 +3,21 @@ import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 import { daysSinceTimestamp } from "main/utils/dateUtils";
+import { toast } from "react-toastify";
 
 export default function CommonsOverview({ commonsPlus, currentUser }) {
 
     let navigate = useNavigate();
-    // Stryker disable next-line all
-    const leaderboardButtonClick = () => { navigate("/leaderboard/" + commonsPlus.commons.id) };
+
+    const leaderboardButtonClick = () => {
+        if (currentUser) {
+            // Stryker disable next-line all
+            navigate("/leaderboard/" + commonsPlus.commons.id);
+        } else {
+            // Display a toast message indicating the user should log in
+            toast("Please log in before trying the leaderboard feature");
+        }
+    };
     const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commonsPlus.commons.showLeaderboard );
     return (
         <Card data-testid="CommonsOverview">

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -10,7 +10,6 @@ export default function CommonsOverview({ commonsPlus, currentUser }) {
     let navigate = useNavigate();
 
     const leaderboardButtonClick = () => {
-        // Stryker disable next-line all: can't test redirected address
         if (currentUser) {navigate("/leaderboard/" + commonsPlus.commons.id);} else {
             // Display a toast message indicating the user should log in
             toast("Please log in before trying the leaderboard feature");

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -10,10 +10,8 @@ export default function CommonsOverview({ commonsPlus, currentUser }) {
     let navigate = useNavigate();
 
     const leaderboardButtonClick = () => {
-        if (currentUser) {
-            // Stryker disable next-line all
-            navigate("/leaderboard/" + commonsPlus.commons.id);
-        } else {
+        // Stryker disable next-line all: can't test redirected address
+        if (currentUser) {navigate("/leaderboard/" + commonsPlus.commons.id);} else {
             // Display a toast message indicating the user should log in
             toast("Please log in before trying the leaderboard feature");
         }

--- a/frontend/src/main/components/Commons/FarmStats.js
+++ b/frontend/src/main/components/Commons/FarmStats.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "react-bootstrap";
 import { ProgressBar } from "react-bootstrap";
+import {parseMoney} from "main/utils/MoneyParsing";
 
 const FarmStats = ({userCommons}) => {
     return (
@@ -9,7 +10,7 @@ const FarmStats = ({userCommons}) => {
         <Card.Body>
             {/* update total wealth and cow health with data from fixture */}
             <Card.Title className="text-center">
-                💰 Total Wealth: ${userCommons.totalWealth.toFixed(2)}
+                💰 Total Wealth: ${parseMoney(userCommons.totalWealth)}
             </Card.Title>
             <Card.Text>
                 Total Cows Bought: {userCommons.cowsBought}

--- a/frontend/src/main/pages/DemoPlayPage.js
+++ b/frontend/src/main/pages/DemoPlayPage.js
@@ -12,12 +12,14 @@ import dummy from "assets/UserHomeDummy.json";
 
 export default function DemoPlayPage() {
 
+    // eslint-disable-next-line no-unused-vars
     const  commonsId  = 0;
-    const  currentUser  = 0;
+    const  currentUser  = null;
 
     const userCommons = dummy['SessionInfo'];
     const commonsPlus = dummy['SessionInfo2'];
     const userCommonsProfits = dummy['Transactions'];
+    // eslint-disable-next-line no-unused-vars
     const userPagedProfits = dummy['PagedTransactions'];
 
     const onBuy = () => {
@@ -33,16 +35,14 @@ export default function DemoPlayPage() {
         <div data-testid="playpage-div">
             <BasicLayout >
                 <Container >
-                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
+                    <CommonsPlay currentUser={currentUser} />
+                    <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />
                     <br />
-                    {!!userCommons && !!commonsPlus &&
-                        <CardGroup >
-                            <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
-                            <FarmStats userCommons={userCommons} />
-                            <Profits userCommons={userCommons} profits={userCommonsProfits} />
-                        </CardGroup>
-                    }
+                    <CardGroup >
+                        <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
+                        <FarmStats userCommons={userCommons} />
+                        <Profits userCommons={userCommons} profits={userCommonsProfits} />
+                    </CardGroup>
                 </Container>
             </BasicLayout>
         </div>

--- a/frontend/src/main/pages/DemoPlayPage.js
+++ b/frontend/src/main/pages/DemoPlayPage.js
@@ -1,0 +1,157 @@
+import React from "react";
+import { Container, CardGroup } from "react-bootstrap";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CommonsOverview from "main/components/Commons/CommonsOverview";
+import CommonsPlay from "main/components/Commons/CommonsPlay";
+import FarmStats from "main/components/Commons/FarmStats";
+import ManageCows from "main/components/Commons/ManageCows";
+import Profits from "main/components/Commons/Profits";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useCurrentUser } from "main/utils/currentUser";
+import Background from "../../assets/PlayPageBackground.png";
+import dummy from "assets/UserHomeDummy.json";
+
+export default function PlayPage() {
+
+    const { commonsId } = useParams();
+    const { data: currentUser } = useCurrentUser();
+
+    // Stryker disable all: disable for axios API call, hard to inserted it within ternary expressions
+    const { data: userCommons } =
+        currentUser.loggedIn
+            ? useBackend(
+                [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
+                {
+                    method: "GET",
+                    url: "/api/usercommons/forcurrentuser",
+                    params: {
+                        commonsId: commonsId
+                    }
+                }
+            )
+            :dummy['SessionInfo'];
+
+    const { data: commonsPlus } =
+        currentUser.loggedIn
+            ? useBackend(
+                [`/api/commons/plus?id=${commonsId}`],
+                {
+                    method: "GET",
+                    url: "/api/commons/plus",
+                    params: {
+                        id: commonsId
+                    }
+                }
+            )
+            :dummy['SessionInfo2'];
+
+    const { data: userCommonsProfits } =
+        currentUser.loggedIn
+            ? useBackend(
+                [`/api/profits/all/commonsid?commonsId=${commonsId}`],
+                {
+                    method: "GET",
+                    url: "/api/profits/all/commonsid",
+                    params: {
+                        commonsId: commonsId
+                    }
+                }
+            )
+            :dummy['Transactions'];
+
+    const { data: userpagedProfits } =
+        currentUser.loggedIn
+            ? useBackend(
+                [`/api/profits/paged/commonsid?commonsId=${commonsId}`],
+                {
+                    method: "GET",
+                    url: "/api/profits/paged/commonsid",
+                    params: {
+                        commonsId: commonsId
+                    }
+                }
+            )
+            :dummy['PagedTransactions'];
+
+
+    const objectToAxiosParamsBuy = (newUserCommons) => ({
+        url: "/api/usercommons/buy",
+        method: "PUT",
+        data: newUserCommons,
+        params: {
+            commonsId: commonsId
+        }
+    });
+
+    const objectToAxiosParamsSell = (newUserCommons) => ({
+        url: "/api/usercommons/sell",
+        method: "PUT",
+        data: newUserCommons,
+        params: {
+            commonsId: commonsId
+        }
+    });
+
+    const mutationbuy = useBackendMutation(
+        objectToAxiosParamsBuy,
+        null,
+        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+    );
+
+    const mutationsell = useBackendMutation(
+        objectToAxiosParamsSell,
+        { onSuccess: onSuccessSell },
+        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+    );
+    // Stryker restore all
+
+
+    const onBuy = (userCommons) => {
+        mutationbuy.mutate(userCommons)
+    };
+
+
+    const onSuccessSell = () => {
+        toast(`Cow sold!`);
+    }
+
+    const onSell = (userCommons) => {
+        mutationsell.mutate(userCommons)
+    };
+
+    console.log("----------------1---------------");
+    console.log(commonsId);
+    console.log("----------------2---------------");
+    console.log(currentUser);
+    console.log("----------------3---------------");
+    console.log(userCommons);
+    console.log("----------------4---------------");
+    console.log(commonsPlus);
+    console.log("----------------5---------------");
+    console.log(userCommonsProfits);
+    console.log("----------------6---------------");
+    console.log(userpagedProfits);
+
+
+    return (
+        <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
+            <BasicLayout >
+                <Container >
+                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
+                    <br />
+                    {!!userCommons && !!commonsPlus &&
+                        <CardGroup >
+                            <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
+                            <FarmStats userCommons={userCommons} />
+                            <Profits userCommons={userCommons} profits={userCommonsProfits} />
+                        </CardGroup>
+                    }
+                </Container>
+            </BasicLayout>
+        </div>
+    )
+}

--- a/frontend/src/main/pages/DemoPlayPage.js
+++ b/frontend/src/main/pages/DemoPlayPage.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Container, CardGroup } from "react-bootstrap";
-import { useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -9,135 +8,29 @@ import CommonsPlay from "main/components/Commons/CommonsPlay";
 import FarmStats from "main/components/Commons/FarmStats";
 import ManageCows from "main/components/Commons/ManageCows";
 import Profits from "main/components/Commons/Profits";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
-import { useCurrentUser } from "main/utils/currentUser";
-import Background from "../../assets/PlayPageBackground.png";
 import dummy from "assets/UserHomeDummy.json";
 
-export default function PlayPage() {
+export default function DemoPlayPage() {
 
-    const { commonsId } = useParams();
-    const { data: currentUser } = useCurrentUser();
+    const  commonsId  = 0;
+    const  currentUser  = 0;
 
-    // Stryker disable all: disable for axios API call, hard to inserted it within ternary expressions
-    const { data: userCommons } =
-        currentUser.loggedIn
-            ? useBackend(
-                [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
-                {
-                    method: "GET",
-                    url: "/api/usercommons/forcurrentuser",
-                    params: {
-                        commonsId: commonsId
-                    }
-                }
-            )
-            :dummy['SessionInfo'];
+    const userCommons = dummy['SessionInfo'];
+    const commonsPlus = dummy['SessionInfo2'];
+    const userCommonsProfits = dummy['Transactions'];
+    const userPagedProfits = dummy['PagedTransactions'];
 
-    const { data: commonsPlus } =
-        currentUser.loggedIn
-            ? useBackend(
-                [`/api/commons/plus?id=${commonsId}`],
-                {
-                    method: "GET",
-                    url: "/api/commons/plus",
-                    params: {
-                        id: commonsId
-                    }
-                }
-            )
-            :dummy['SessionInfo2'];
-
-    const { data: userCommonsProfits } =
-        currentUser.loggedIn
-            ? useBackend(
-                [`/api/profits/all/commonsid?commonsId=${commonsId}`],
-                {
-                    method: "GET",
-                    url: "/api/profits/all/commonsid",
-                    params: {
-                        commonsId: commonsId
-                    }
-                }
-            )
-            :dummy['Transactions'];
-
-    const { data: userpagedProfits } =
-        currentUser.loggedIn
-            ? useBackend(
-                [`/api/profits/paged/commonsid?commonsId=${commonsId}`],
-                {
-                    method: "GET",
-                    url: "/api/profits/paged/commonsid",
-                    params: {
-                        commonsId: commonsId
-                    }
-                }
-            )
-            :dummy['PagedTransactions'];
-
-
-    const objectToAxiosParamsBuy = (newUserCommons) => ({
-        url: "/api/usercommons/buy",
-        method: "PUT",
-        data: newUserCommons,
-        params: {
-            commonsId: commonsId
-        }
-    });
-
-    const objectToAxiosParamsSell = (newUserCommons) => ({
-        url: "/api/usercommons/sell",
-        method: "PUT",
-        data: newUserCommons,
-        params: {
-            commonsId: commonsId
-        }
-    });
-
-    const mutationbuy = useBackendMutation(
-        objectToAxiosParamsBuy,
-        null,
-        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
-    );
-
-    const mutationsell = useBackendMutation(
-        objectToAxiosParamsSell,
-        { onSuccess: onSuccessSell },
-        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
-    );
-    // Stryker restore all
-
-
-    const onBuy = (userCommons) => {
-        mutationbuy.mutate(userCommons)
+    const onBuy = () => {
+        toast(`Buy cow demo`);
     };
 
-
-    const onSuccessSell = () => {
-        toast(`Cow sold!`);
-    }
-
-    const onSell = (userCommons) => {
-        mutationsell.mutate(userCommons)
+    const onSell = () => {
+        toast(`Sold cow demo`);
     };
-
-    console.log("----------------1---------------");
-    console.log(commonsId);
-    console.log("----------------2---------------");
-    console.log(currentUser);
-    console.log("----------------3---------------");
-    console.log(userCommons);
-    console.log("----------------4---------------");
-    console.log(commonsPlus);
-    console.log("----------------5---------------");
-    console.log(userCommonsProfits);
-    console.log("----------------6---------------");
-    console.log(userpagedProfits);
 
 
     return (
-        <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
+        <div data-testid="playpage-div">
             <BasicLayout >
                 <Container >
                     {!!currentUser && <CommonsPlay currentUser={currentUser} />}

--- a/frontend/src/main/pages/DemoPlayPage.js
+++ b/frontend/src/main/pages/DemoPlayPage.js
@@ -27,7 +27,7 @@ export default function DemoPlayPage() {
     };
 
     const onSell = () => {
-        toast(`Sold cow demo`);
+        toast(`Sell cow demo`);
     };
 
 

--- a/frontend/src/main/pages/DemoPlayPage.js
+++ b/frontend/src/main/pages/DemoPlayPage.js
@@ -19,8 +19,7 @@ export default function DemoPlayPage() {
     const userCommons = dummy['SessionInfo'];
     const commonsPlus = dummy['SessionInfo2'];
     const userCommonsProfits = dummy['Transactions'];
-    // eslint-disable-next-line no-unused-vars
-    const userPagedProfits = dummy['PagedTransactions'];
+    //const userPagedProfits = dummy['PagedTransactions'];
 
     const onBuy = () => {
         toast(`Buy cow demo`);

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -15,134 +15,124 @@ import Background from "../../assets/PlayPageBackground.png";
 
 export default function PlayPage() {
 
-    const { commonsId } = useParams();
-    const { data: currentUser } = useCurrentUser();
+  const { commonsId } = useParams();
+  const { data: currentUser } = useCurrentUser();
 
-    // Stryker disable all
-    const { data: userCommons } =
-        useBackend(
-            [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
-            {
-                method: "GET",
-                url: "/api/usercommons/forcurrentuser",
-                params: {
-                    commonsId: commonsId
-                }
-            }
-        );
-
-    const { data: commonsPlus } =
-        useBackend(
-            [`/api/commons/plus?id=${commonsId}`],
-            {
-                method: "GET",
-                url: "/api/commons/plus",
-                params: {
-                    id: commonsId
-                }
-            }
-        );
-
-    const { data: userCommonsProfits } =
-        useBackend(
-            [`/api/profits/all/commonsid?commonsId=${commonsId}`],
-            {
-                method: "GET",
-                url: "/api/profits/all/commonsid",
-                params: {
-                    commonsId: commonsId
-                }
-            }
-        );
-
-    const { data: userpagedProfits } =
-        useBackend(
-            [`/api/profits/paged/commonsid?commonsId=${commonsId}`],
-            {
-                method: "GET",
-                url: "/api/profits/paged/commonsid",
-                params: {
-                    commonsId: commonsId
-                }
-            }
-        );
-
-
-    const objectToAxiosParamsBuy = (newUserCommons) => ({
-        url: "/api/usercommons/buy",
-        method: "PUT",
-        data: newUserCommons,
+  // Stryker disable all 
+  const { data: userCommons } =
+    useBackend(
+      [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
+      {
+        method: "GET",
+        url: "/api/usercommons/forcurrentuser",
         params: {
-            commonsId: commonsId
+          commonsId: commonsId
         }
-    });
+      }
+    );
+  // Stryker restore all 
 
-    const objectToAxiosParamsSell = (newUserCommons) => ({
-        url: "/api/usercommons/sell",
-        method: "PUT",
-        data: newUserCommons,
+  // Stryker disable all
+  const { data: commonsPlus } =
+    useBackend(
+      [`/api/commons/plus?id=${commonsId}`],
+      {
+        method: "GET",
+        url: "/api/commons/plus",
         params: {
-            commonsId: commonsId
+          id: commonsId
         }
-    });
-
-    const mutationbuy = useBackendMutation(
-        objectToAxiosParamsBuy,
-        null,
-        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+      }
     );
+  // Stryker restore all
 
-    const mutationsell = useBackendMutation(
-        objectToAxiosParamsSell,
-        { onSuccess: onSuccessSell },
-        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+  // Stryker disable all 
+  const { data: userCommonsProfits } =
+    useBackend(
+      [`/api/profits/all/commonsid?commonsId=${commonsId}`],
+      {
+        method: "GET",
+        url: "/api/profits/all/commonsid",
+        params: {
+          commonsId: commonsId
+        }
+      }
     );
-    // Stryker restore all
+  // Stryker restore all 
 
 
-    const onBuy = (userCommons) => {
-        mutationbuy.mutate(userCommons)
-    };
-
-
-    const onSuccessSell = () => {
-        toast(`Cow sold!`);
+  // Stryker disable all (can't check if commonsId is null because it is mocked)
+  const objectToAxiosParamsBuy = (newUserCommons) => ({
+    url: "/api/usercommons/buy",
+    method: "PUT",
+    data: newUserCommons,
+    params: {
+      commonsId: commonsId
     }
-
-    const onSell = (userCommons) => {
-        mutationsell.mutate(userCommons)
-    };
-
-    console.log("----------------1---------------");
-    console.log(commonsId);
-    console.log("----------------2---------------");
-    console.log(currentUser);
-    console.log("----------------3---------------");
-    console.log(userCommons);
-    console.log("----------------4---------------");
-    console.log(commonsPlus);
-    console.log("----------------5---------------");
-    console.log(userCommonsProfits);
-    console.log("----------------6---------------");
-    console.log(userpagedProfits);
+  });
+  // Stryker restore all
 
 
-    return (
-        <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
-            <BasicLayout >
-                <Container >
-                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
-                    <br />
-                    {!!userCommons && !!commonsPlus &&
-                        <CardGroup >
-                            <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
-                            <FarmStats userCommons={userCommons} />
-                            <Profits userCommons={userCommons} profits={userCommonsProfits} />
-                        </CardGroup>
-                    }
-                </Container>
-            </BasicLayout>
-        </div>
-    )
+  // Stryker disable all 
+  const mutationbuy = useBackendMutation(
+    objectToAxiosParamsBuy,
+    null,
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+  );
+  // Stryker restore all 
+
+
+  const onBuy = (userCommons) => {
+    mutationbuy.mutate(userCommons)
+  };
+
+
+  const onSuccessSell = () => {
+    toast(`Cow sold!`);
+  }
+
+  // Stryker disable all 
+  const objectToAxiosParamsSell = (newUserCommons) => ({
+    url: "/api/usercommons/sell",
+    method: "PUT",
+    data: newUserCommons,
+    params: {
+      commonsId: commonsId
+    }
+  });
+  // Stryker restore all 
+
+
+  // Stryker disable all 
+  const mutationsell = useBackendMutation(
+    objectToAxiosParamsSell,
+    { onSuccess: onSuccessSell },
+    [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
+  );
+  // Stryker restore all 
+
+
+  const onSell = (userCommons) => {
+    mutationsell.mutate(userCommons)
+  };
+
+  return (
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
+      <BasicLayout >
+        <Container >
+          {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+          {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
+          <br />
+          {!!userCommons && !!commonsPlus &&
+            <CardGroup >
+              <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
+              <FarmStats userCommons={userCommons} />
+              <Profits userCommons={userCommons} profits={userCommonsProfits} />
+            </CardGroup>
+          }
+        </Container>
+      </BasicLayout>
+    </div>
+  )
 }

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -117,6 +117,8 @@ export default function PlayPage() {
     mutationsell.mutate(userCommons)
   };
 
+  
+
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
       <BasicLayout >

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -15,126 +15,134 @@ import Background from "../../assets/PlayPageBackground.png";
 
 export default function PlayPage() {
 
-  const { commonsId } = useParams();
-  const { data: currentUser } = useCurrentUser();
+    const { commonsId } = useParams();
+    const { data: currentUser } = useCurrentUser();
 
-  // Stryker disable all 
-  const { data: userCommons } =
-    useBackend(
-      [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
-      {
-        method: "GET",
-        url: "/api/usercommons/forcurrentuser",
+    // Stryker disable all
+    const { data: userCommons } =
+        useBackend(
+            [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
+            {
+                method: "GET",
+                url: "/api/usercommons/forcurrentuser",
+                params: {
+                    commonsId: commonsId
+                }
+            }
+        );
+
+    const { data: commonsPlus } =
+        useBackend(
+            [`/api/commons/plus?id=${commonsId}`],
+            {
+                method: "GET",
+                url: "/api/commons/plus",
+                params: {
+                    id: commonsId
+                }
+            }
+        );
+
+    const { data: userCommonsProfits } =
+        useBackend(
+            [`/api/profits/all/commonsid?commonsId=${commonsId}`],
+            {
+                method: "GET",
+                url: "/api/profits/all/commonsid",
+                params: {
+                    commonsId: commonsId
+                }
+            }
+        );
+
+    const { data: userpagedProfits } =
+        useBackend(
+            [`/api/profits/paged/commonsid?commonsId=${commonsId}`],
+            {
+                method: "GET",
+                url: "/api/profits/paged/commonsid",
+                params: {
+                    commonsId: commonsId
+                }
+            }
+        );
+
+
+    const objectToAxiosParamsBuy = (newUserCommons) => ({
+        url: "/api/usercommons/buy",
+        method: "PUT",
+        data: newUserCommons,
         params: {
-          commonsId: commonsId
+            commonsId: commonsId
         }
-      }
-    );
-  // Stryker restore all 
+    });
 
-  // Stryker disable all
-  const { data: commonsPlus } =
-    useBackend(
-      [`/api/commons/plus?id=${commonsId}`],
-      {
-        method: "GET",
-        url: "/api/commons/plus",
+    const objectToAxiosParamsSell = (newUserCommons) => ({
+        url: "/api/usercommons/sell",
+        method: "PUT",
+        data: newUserCommons,
         params: {
-          id: commonsId
+            commonsId: commonsId
         }
-      }
+    });
+
+    const mutationbuy = useBackendMutation(
+        objectToAxiosParamsBuy,
+        null,
+        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
     );
-  // Stryker restore all
 
-  // Stryker disable all 
-  const { data: userCommonsProfits } =
-    useBackend(
-      [`/api/profits/all/commonsid?commonsId=${commonsId}`],
-      {
-        method: "GET",
-        url: "/api/profits/all/commonsid",
-        params: {
-          commonsId: commonsId
-        }
-      }
+    const mutationsell = useBackendMutation(
+        objectToAxiosParamsSell,
+        { onSuccess: onSuccessSell },
+        [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
     );
-  // Stryker restore all 
+    // Stryker restore all
 
 
-  // Stryker disable all (can't check if commonsId is null because it is mocked)
-  const objectToAxiosParamsBuy = (newUserCommons) => ({
-    url: "/api/usercommons/buy",
-    method: "PUT",
-    data: newUserCommons,
-    params: {
-      commonsId: commonsId
+    const onBuy = (userCommons) => {
+        mutationbuy.mutate(userCommons)
+    };
+
+
+    const onSuccessSell = () => {
+        toast(`Cow sold!`);
     }
-  });
-  // Stryker restore all
+
+    const onSell = (userCommons) => {
+        mutationsell.mutate(userCommons)
+    };
+
+    console.log("----------------1---------------");
+    console.log(commonsId);
+    console.log("----------------2---------------");
+    console.log(currentUser);
+    console.log("----------------3---------------");
+    console.log(userCommons);
+    console.log("----------------4---------------");
+    console.log(commonsPlus);
+    console.log("----------------5---------------");
+    console.log(userCommonsProfits);
+    console.log("----------------6---------------");
+    console.log(userpagedProfits);
 
 
-  // Stryker disable all 
-  const mutationbuy = useBackendMutation(
-    objectToAxiosParamsBuy,
-    null,
-    // Stryker disable next-line all : hard to set up test for caching
-    [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
-  );
-  // Stryker restore all 
-
-
-  const onBuy = (userCommons) => {
-    mutationbuy.mutate(userCommons)
-  };
-
-
-  const onSuccessSell = () => {
-    toast(`Cow sold!`);
-  }
-
-  // Stryker disable all 
-  const objectToAxiosParamsSell = (newUserCommons) => ({
-    url: "/api/usercommons/sell",
-    method: "PUT",
-    data: newUserCommons,
-    params: {
-      commonsId: commonsId
-    }
-  });
-  // Stryker restore all 
-
-
-  // Stryker disable all 
-  const mutationsell = useBackendMutation(
-    objectToAxiosParamsSell,
-    { onSuccess: onSuccessSell },
-    [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
-  );
-  // Stryker restore all 
-
-
-  const onSell = (userCommons) => {
-    mutationsell.mutate(userCommons)
-  };
-
-  
-
-  return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
-      <BasicLayout >
-        <Container >
-          {!!currentUser && <CommonsPlay currentUser={currentUser} />}
-          {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
-          <br />
-          {!!userCommons && !!commonsPlus &&
-            <CardGroup >
-              <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
-              <FarmStats userCommons={userCommons} />
-              <Profits userCommons={userCommons} profits={userCommonsProfits} />
-            </CardGroup>
-          }
-        </Container>
-      </BasicLayout>
-    </div>
-  )
+    return (
+        <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }} data-testid="playpage-div">
+            <BasicLayout >
+                <Container >
+                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {!!commonsPlus && <CommonsOverview commonsPlus={commonsPlus} currentUser={currentUser} />}
+                    <br />
+                    {!!userCommons && !!commonsPlus &&
+                        <CardGroup >
+                            <ManageCows userCommons={userCommons} commons={commonsPlus.commons} onBuy={onBuy} onSell={onSell} />
+                            <FarmStats userCommons={userCommons} />
+                            <Profits userCommons={userCommons} profits={userCommonsProfits} />
+                        </CardGroup>
+                    }
+                </Container>
+            </BasicLayout>
+        </div>
+    )
 }

--- a/frontend/src/main/utils/MoneyParsing.js
+++ b/frontend/src/main/utils/MoneyParsing.js
@@ -1,8 +1,8 @@
 
 export function parseMoney(value) {
-    const prefixes = ["", "K", "M", "B", "T", "P", "E", "Z", "Y"];
+    const prefixes = ["", "K", "M", "B", "T", "P", "E", "Z", "Y", "R", "Q"];
     let scaledValue = value;
-    if (value <= 0.01){return "0";}
+    if (value < 0.01){return "0";}
 
     for (let i = prefixes.length - 1; i >= 1; i--) {
         const scale = Math.pow(10, i * 3);

--- a/frontend/src/main/utils/MoneyParsing.js
+++ b/frontend/src/main/utils/MoneyParsing.js
@@ -1,11 +1,11 @@
 
 export function parseMoney(value) {
-    const prefixes = ["", "K", "M", "B", "T", "P", "E", "Z", "Y", "R", "Q"];
+    const prefixes = ["K", "M", "B", "T", "P", "E", "Z", "Y", "R", "Q"];
     let scaledValue = value;
     if (value < 0.01){return "0";}
 
-    for (let i = prefixes.length - 1; i >= 1; i--) {
-        const scale = Math.pow(10, i * 3);
+    for (let i = 9; i >= 0; i--) {
+        const scale = Math.pow(10, (i+1) * 3);
         if (scaledValue >= scale) {
             const scaled = scaledValue / scale;
             return scaled.toFixed(3) + prefixes[i];

--- a/frontend/src/main/utils/MoneyParsing.js
+++ b/frontend/src/main/utils/MoneyParsing.js
@@ -1,0 +1,17 @@
+
+export function parseMoney(value) {
+    const prefixes = ["", "K", "M", "B", "T", "P", "E", "Z", "Y"];
+    let scaledValue = value;
+    if (value <= 0.01){return "0";}
+
+    for (let i = prefixes.length - 1; i >= 1; i--) {
+        const scale = Math.pow(10, i * 3);
+        if (scaledValue >= scale) {
+            const scaled = scaledValue / scale;
+            return scaled.toFixed(3) + prefixes[i];
+        }
+    }
+
+    return scaledValue.toFixed(3);
+}
+

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -11,6 +11,7 @@ import leaderboardFixtures from "fixtures/leaderboardFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+import { toast } from 'react-toastify';
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -19,6 +20,10 @@ jest.mock("react-router-dom", () => ({
         commonsId: 1
     }),
     useNavigate: () => mockNavigate
+}));
+
+jest.mock('react-toastify', () => ({
+    toast: jest.fn(),
 }));
 
 describe("CommonsOverview tests", () => {
@@ -36,6 +41,19 @@ describe("CommonsOverview tests", () => {
         render(
             <CommonsOverview commonsPlus={commonsPlusFixtures.oneCommonsPlus[0]} />
         );
+    });
+
+    test("Popping out toast messages for visitor", async () => {
+        render(
+            <CommonsOverview commonsPlus={commonsPlusFixtures.threeCommonsPlus[1]} currentUser={null}/>
+        );
+        expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId("user-leaderboard-button"));
+        // Expect visitor receives toast message
+        expect(toast).toHaveBeenCalledWith(
+            'Please log in before trying the leaderboard feature'
+        );
+
     });
 
     test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -74,6 +74,7 @@ describe("CommonsOverview tests", () => {
         expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
         const leaderboardButton = screen.getByTestId("user-leaderboard-button");
         fireEvent.click(leaderboardButton);
+        expect(toast).not.toHaveBeenCalled();
         //expect(mockNavigate).toBeCalledWith({ "to": "/leaderboard/1" });
     });
 

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -75,7 +75,7 @@ describe("CommonsOverview tests", () => {
         const leaderboardButton = screen.getByTestId("user-leaderboard-button");
         fireEvent.click(leaderboardButton);
         expect(toast).not.toHaveBeenCalled();
-        //expect(mockNavigate).toBeCalledWith({ "to": "/leaderboard/1" });
+        expect(mockNavigate).toBeCalledWith( "/leaderboard/4" );
     });
 
     test("No LeaderboardPage for an ordinary user when commons has showLeaderboard = false", async () => {

--- a/frontend/src/tests/components/Commons/FarmStats.test.js
+++ b/frontend/src/tests/components/Commons/FarmStats.test.js
@@ -15,7 +15,7 @@ describe("FarmStats tests", () => {
         );
 
         await waitFor (() => {
-            expect(screen.getByText(/Total Wealth: \$1000/)).toBeInTheDocument();
+            expect(screen.getByText(/Total Wealth: \$1.000K/)).toBeInTheDocument();
         });
 
         expect(screen.getByText(/Cow Health: 98%/)).toBeInTheDocument();

--- a/frontend/src/tests/pages/DemoPlayPage.test.js
+++ b/frontend/src/tests/pages/DemoPlayPage.test.js
@@ -1,9 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import AxiosMockAdapter from "axios-mock-adapter";
 import DemoPlayPage from "main/pages/DemoPlayPage";
-import {toast} from "react-toastify";
 
 
 jest.mock("react-router-dom", () => ({

--- a/frontend/src/tests/pages/DemoPlayPage.test.js
+++ b/frontend/src/tests/pages/DemoPlayPage.test.js
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import AxiosMockAdapter from "axios-mock-adapter";
+import DemoPlayPage from "main/pages/DemoPlayPage";
+import {toast} from "react-toastify";
+
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+}));
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("DemoPlayPage tests", () => {
+    const queryClient = new QueryClient();
+
+
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DemoPlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+
+    test("click buy, sell, and leaderboard buttons", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DemoPlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("buy-cow-button")).toBeInTheDocument();
+        const buyCowButton = screen.getByTestId("buy-cow-button");
+        fireEvent.click(buyCowButton);
+        expect(mockToast).toBeCalledWith("Buy cow demo");
+        //await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
+        const sellCowButton = screen.getByTestId("sell-cow-button");
+        fireEvent.click(sellCowButton);
+        expect(mockToast).toBeCalledWith("Sell cow demo");
+        expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId("user-leaderboard-button"));
+        expect(mockToast).toHaveBeenCalledWith(
+            'Please log in before trying the leaderboard feature'
+        );
+
+    });
+
+    test("Static texts are displayed as expected", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DemoPlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText(/Announcements/)).toBeInTheDocument();
+        expect(await screen.findByTestId("CommonsPlay")).toBeInTheDocument();
+        expect(await screen.findByText(/5.564B/)).toBeInTheDocument();
+        expect(await screen.findByText(/Cow Health: 20.5%/)).toBeInTheDocument();
+        expect(await screen.findByText(/Market Cow Price: /)).toBeInTheDocument();
+        expect(await screen.findByText(/You will earn profits from milking your cows everyday at 4am./)).toBeInTheDocument();
+        expect(await screen.findByText(/Market Cow Price: /)).toBeInTheDocument();
+        expect(await screen.findByText(/Total Players: 1/)).toBeInTheDocument();
+        expect(await screen.findByText(/1500/)).toBeInTheDocument();
+        expect(await screen.findByText('2023-08-19')).toBeInTheDocument();
+
+    });
+});

--- a/frontend/src/tests/utils/MoneyParsing.test.js
+++ b/frontend/src/tests/utils/MoneyParsing.test.js
@@ -1,0 +1,32 @@
+import { parseMoney } from 'main/utils/MoneyParsing.js';
+
+describe('parseMoney function', () => {
+    it('should return "0" if the value is less than to 0.01', () => {
+        expect(parseMoney(0)).toBe("0");
+        expect(parseMoney(-2.3)).toBe("0");
+        expect(parseMoney(-100)).toBe("0");
+        expect(parseMoney(0.02)).toBe("0.020");
+        expect(parseMoney(0.01)).toBe("0.010");
+        expect(parseMoney(0.005)).toBe("0");
+    });
+
+    it('should correctly format values using SI prefixes', () => {
+        expect(parseMoney(1000)).toBe("1.000K");
+        expect(parseMoney(1552)).toBe("1.552K");
+        expect(parseMoney(1552000)).toBe("1.552M");
+        expect(parseMoney(45645000000)).toBe("45.645B");
+        expect(parseMoney(45645_000_000_000)).toBe("45.645T");
+        expect(parseMoney(45645_000_000_000_000)).toBe("45.645P");
+        expect(parseMoney(45645_000_000_000_000_000)).toBe("45.645E");
+        expect(parseMoney(45645_000_000_000_000_000_000)).toBe("45.645Z");
+        expect(parseMoney(45645_000_000_000_000_000_000_000)).toBe("45.645Y");
+        expect(parseMoney(123456_000_000_000_000_000_000_000_000)).toBe("123.456R");
+        expect(parseMoney(123456_000_000_000_000_000_000_000_000_000)).toBe("123.456Q");
+    });
+
+    it('should return the input value formatted to 3 decimal places if no prefix applies', () => {
+
+        expect(parseMoney(999)).toBe("999.000");
+        expect(parseMoney(123.23)).toBe("123.230");
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -11,11 +11,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
@@ -47,5 +54,34 @@ public class ProfitsController extends ApiController {
         Iterable<Profit> profits = profitRepository.findAllByUserCommons(userCommons);
 
         return profits;
+    }
+
+    @Operation(summary = "Get all profits belonging to a user commons as a user via CommonsID with pagination")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/paged/commonsid")
+    public Page<Profit> allProfitsByCommonsIdWithPagination(
+            @Parameter(name = "commonsId") @RequestParam Long commonsId,
+            @Parameter(name = "pageNumber", description = "Page number, 0 indexed") @RequestParam(defaultValue = "0") int pageNumber,
+            @Parameter(name = "pageSize", description = "Number of records per page") @RequestParam(defaultValue = "7") int pageSize
+
+    ) {
+        Long userId = getCurrentUser().getUser().getId();
+
+        UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(UserCommons.class, "commonsId", commonsId, "userId", userId));
+
+        Iterable<Profit> iterableProfits = profitRepository.findAllByUserCommons(userCommons);
+
+        List<Profit> allProfits = new ArrayList<>();
+        iterableProfits.forEach(allProfits::add);
+
+        int start = pageNumber * pageSize;
+        int end = Math.min((start + pageSize), allProfits.size());
+        List<Profit> paginatedProfits = allProfits.subList(start, end);
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Page<Profit> profitsPage = new PageImpl<>(paginatedProfits, pageable, allProfits.size());
+
+        return profitsPage;
     }
 }


### PR DESCRIPTION
## Overview
In this PR, I created a demo play page located at `/demo/play` for visitors and front end developers for developing purpose. Static dummy data from `UserHomeDummy.json` is used to fill the content. The demo page only displays static texts so that the front end developers can focus on UI design only without the need to be concerned about security and back end. 
This PR lays the groundwork for implementing pagination functionality and better UI in the future. 

### Minor fix
-  `util`: Introduced a parseMoney function that handles value formatting with SI prefixes. The function accepts a double numeric value and scales it using SI prefixes like "K", "M", "B", and so on, to improve readability for large numbers. The previous function uses responses.toFixed(2). The length of integer part may be very long, which hinders future UI design. 
-  `FarmStats.js`: parseMoney function is used. 
-  `CommonOverview.js`: added additional handlings for the submit button. Logged out users will receive toast messages.


## Discussion - Security Concerns
URL end point '/demo/play' is open to public without protection of Google OAuth. If dokku doens't have rate limiting protection, it may be vulnerable to DDoS attacks. I wonder whether it's a secured approach. If it is unsecured, we can use it as a dev branch instead of a production branch.  


## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/68430949/7063155c-c4d6-49bd-8cc0-0342dd729026)

## Tests
Frontend Coverage & Mutation: 100%

## Linked Issues
Closes #88 
Mid part of #6
