### PR TITLE
Feature: Add templates for Chat Frontend Components

### DIFF
--- a/frontend/src/fixtures/chatMessageFixtures.js
+++ b/frontend/src/fixtures/chatMessageFixtures.js
@@ -1,0 +1,168 @@
+export const chatMessageFixtures = {
+    threeChatMessages: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 3,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:28.325+00:00",
+            "message": "This is another test for chat messaging",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 2,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "Hello World How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        }
+    ],
+    oneChatMessage: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        }
+    ],
+    twelveChatMessages: [
+        {
+            "id": 1,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-17T23:57:46.576+00:00",
+            "message": "This should not appear",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 2,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T02:59:11.125+00:00",
+            "message": "This should also be cut off",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 3,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-18T03:00:28.325+00:00",
+            "message": "Hello World",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 4,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-19T23:57:46.576+00:00",
+            "message": "Crazy that you found me up here",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 5,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-20T02:59:11.125+00:00",
+            "message": "How are you doing???",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 6,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-21T02:59:28.325+00:00",
+            "message": "It's hard work writing all these messages",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 7,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-22T23:57:46.576+00:00",
+            "message": "I'm not too creative about it...",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 8,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-23T02:59:11.125+00:00",
+            "message": "Look symbols!! => (*&$#^)@#*^)*&%^(*!&^)(",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 9,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-24T02:59:28.325+00:00",
+            "message": "Hows the project going?",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 10,
+            "userId": 1,
+            "commonsId": 1,
+            "timestamp": "2023-08-24T23:57:46.576+00:00",
+            "message": "More chat testing...",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+        {
+            "id": 11,
+            "userId": 3,
+            "commonsId": 1,
+            "timestamp": "2023-08-25T02:59:11.125+00:00",
+            "message": "This should appear, though",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": true
+        },
+        {
+            "id": 12,
+            "userId": 2,
+            "commonsId": 1,
+            "timestamp": "2023-08-25T02:59:28.325+00:00",
+            "message": "This one too!",
+            "dm": false,
+            "toUserId": 0,
+            "hidden": false
+        },
+    ],
+}

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -2,49 +2,23 @@ const userCommonsFixtures = {
     oneUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
             "cowsBought": 5,
             "cowsSold": 5,
             "cowDeaths": 5
-        }
+        },
     ],
     threeUserCommons:
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -53,22 +27,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "username": "John Adams",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -77,22 +38,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "Thomas Jefferson",
-                "givenName": "Thomas",
-                "familyName": "Jefferson",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "Thomas Jefferson",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -104,22 +52,9 @@ const userCommonsFixtures = {
     fiveUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -128,22 +63,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "username": "John Adams",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -152,22 +74,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "Thomas Jefferson",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -176,22 +85,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":4,
-            "user": {
-                "id": 3,
-                "fullName": "James Madison",
-                "givenName": "James",
-                "familyName": "Madison",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 4,
+            "username": "James Madison",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -200,22 +96,9 @@ const userCommonsFixtures = {
             "cowDeaths": 100
         },
         {
-            "id":5,
-            "user": {
-                "id": 5,
-                "fullName": "James Monroe",
-                "givenName": "James",
-                "familyName": "Monroe",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 5,
+            "username": "James Monroe",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
@@ -227,22 +110,9 @@ const userCommonsFixtures = {
     tenUserCommons: 
     [
         {
-            "id":1,
-            "user": {
-                "id": 1,
-                "fullName": "George Washington",
-                "givenName": "George",
-                "familyName": "Washington",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 1,
+            "username": "George Washington",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -251,22 +121,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":2,
-            "user": {
-                "id": 2,
-                "fullName": "John Adams",
-                "givenName": "John",
-                "familyName": "Adams",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 2,
+            "username": "John Adams",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -275,22 +132,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":3,
-            "user": {
-                "id": 3,
-                "fullName": "Thomas Jefferson",
-                "givenName": "Thomas",
-                "familyName": "Jefferson",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "Thomas Jefferson",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -299,22 +143,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":4,
-            "user": {
-                "id": 3,
-                "fullName": "James Madison",
-                "givenName": "James",
-                "familyName": "Madison",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 3,
+            "username": "James Madison",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -323,22 +154,9 @@ const userCommonsFixtures = {
             "cowDeaths": 100
         },
         {
-            "id":5,
-            "user": {
-                "id": 5,
-                "fullName": "James Monroe",
-                "givenName": "James",
-                "familyName": "Monroe",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 5,
+            "username": "James Monroe",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,
@@ -347,22 +165,9 @@ const userCommonsFixtures = {
             "cowDeaths": 60
         },
         {
-            "id":6,
-            "user": {
-                "id": 6,
-                "fullName": "Ancient McDonald",
-                "givenName": "Ancient",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 6,
+            "username": "Ancient McDonald",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
             "numOfCows": 8,
@@ -371,22 +176,9 @@ const userCommonsFixtures = {
             "cowDeaths": 8
         },
         {
-            "id":7,
-            "user": {
-                "id": 7,
-                "fullName": "Old McDonald",
-                "givenName": "Old",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 7,
+            "username": "Old McDonald",
+            "commonsId":1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
             "numOfCows": 5,
@@ -395,22 +187,9 @@ const userCommonsFixtures = {
             "cowDeaths": 5
         },
         {
-            "id":8,
-            "user": {
-                "id": 8,
-                "fullName": "Middle Aged McDonald",
-                "givenName": "Middle Aged",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 8,
+            "username": "Middle Aged McDonald",
+            "commonsId":1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
             "numOfCows": 1000,
@@ -419,22 +198,9 @@ const userCommonsFixtures = {
             "cowDeaths": 1000
         },
         {
-            "id":9,
-            "user": {
-                "id": 9,
-                "fullName": "Young McDonald",
-                "givenName": "Young",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 9,
+            "username": "Young McDonald",
+            "commonsId":1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
             "numOfCows": 100,
@@ -444,21 +210,9 @@ const userCommonsFixtures = {
         },
         {
             "id":10,
-            "user": {
-                "id": 10,
-                "fullName": "Child McDonald",
-                "givenName": "Child",
-                "familyName": "McDonald",
-            },
-            "commons":  {
-                "id":1,
-                "name":"Table 11",
-                "day": 5,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "showLeaderboard": true,
-                "degradationRate": .5,
-            },
+            "userId": 10,
+            "username": "Child McDonald",
+            "commonsId":1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
             "numOfCows": 60,

--- a/frontend/src/main/components/Chat/ChatDisplay.js
+++ b/frontend/src/main/components/Chat/ChatDisplay.js
@@ -2,7 +2,7 @@ import ChatMessageDisplay from "main/components/Chat/ChatMessageDisplay";
 
 //ChatDisplay Template
 
-const ChatDisplay = ({  }) => {
+const ChatDisplay = () => {
 
     return (
       <div data-testid="ChatDisplay" >

--- a/frontend/src/main/components/Chat/ChatDisplay.js
+++ b/frontend/src/main/components/Chat/ChatDisplay.js
@@ -1,0 +1,14 @@
+import ChatMessageDisplay from "main/components/Chat/ChatMessageDisplay";
+
+//ChatDisplay Template
+
+const ChatDisplay = ({  }) => {
+
+    return (
+      <div data-testid="ChatDisplay" >
+        <ChatMessageDisplay />
+      </div>
+    );
+};
+
+export default ChatDisplay;

--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -3,7 +3,7 @@ import { Form } from "react-bootstrap";
 
 //ChatMessageCreate template
 
-const ChatMessageCreate = ({ }) => {
+const ChatMessageCreate = () => {
 
     const testid = "ChatMessageCreate";
 

--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Form } from "react-bootstrap";
+
+//ChatMessageCreate template
+
+const ChatMessageCreate = ({ }) => {
+
+    const testid = "ChatMessageCreate";
+
+    return (
+        <Form data-testid={testid} >
+            
+        </Form>
+    );
+};
+
+export default ChatMessageCreate;

--- a/frontend/src/main/components/Chat/ChatMessageDisplay.js
+++ b/frontend/src/main/components/Chat/ChatMessageDisplay.js
@@ -1,0 +1,13 @@
+import { Card } from 'react-bootstrap';
+
+const ChatMessageDisplay = ({ }) => {
+
+    const testId = "ChatMessageDisplay";
+
+    return (
+        <Card data-testid={testId}>
+        </Card>
+    );
+};
+
+export default ChatMessageDisplay;

--- a/frontend/src/main/components/Chat/ChatMessageDisplay.js
+++ b/frontend/src/main/components/Chat/ChatMessageDisplay.js
@@ -1,6 +1,6 @@
 import { Card } from 'react-bootstrap';
 
-const ChatMessageDisplay = ({ }) => {
+const ChatMessageDisplay = () => {
 
     const testId = "ChatMessageDisplay";
 

--- a/frontend/src/main/components/Chat/ChatPanel.js
+++ b/frontend/src/main/components/Chat/ChatPanel.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Stack } from 'react-bootstrap';
+import ChatMessageCreate from 'main/components/Chat/ChatMessageCreate';
+import ChatDisplay from 'main/components/Chat/ChatDisplay';
+
+const ChatPanel = ({ commonsId}) => {
+  return (
+    <Stack gap={2} style={{ backgroundColor: 'white' }} data-testid="ChatPanel" > 
+      <ChatDisplay commonsId={commonsId} />
+      <ChatMessageCreate commonsId={commonsId} />
+    </Stack>
+  );
+};
+
+export default ChatPanel;

--- a/frontend/src/tests/components/Chat/ChatPanel.test.js
+++ b/frontend/src/tests/components/Chat/ChatPanel.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from "react-query";
+import ChatPanel from 'main/components/Chat/ChatPanel';
+
+describe('ChatPanel', () => {
+    const commonsId = 1;
+
+    const queryClient = new QueryClient();
+
+    test('renders empty ChatMessageCreate and ChatDisplay', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatPanel commonsId={commonsId} />
+            </QueryClientProvider>
+            );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('ChatDisplay')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('ChatMessageCreate')).toBeInTheDocument();
+        expect(screen.getByTestId('ChatMessageDisplay')).toBeInTheDocument();
+
+        expect(screen.getByTestId('ChatPanel')).toHaveStyle('backgroundColor: white');
+    });
+
+});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add blank templates for the Chat frontend components. This PR must be merged before any of the Chat frontend components' PRs/

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

