### PR TITLE
FEATURE: ChatMessageCreate component

### DIFF
--- a/frontend/src/main/components/Chat/ChatMessageCreate.js
+++ b/frontend/src/main/components/Chat/ChatMessageCreate.js
@@ -1,15 +1,56 @@
 import React from "react";
-import { Form } from "react-bootstrap";
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
 
-//ChatMessageCreate template
+import { useBackendMutation } from "main/utils/useBackend";
 
-const ChatMessageCreate = () => {
+const ChatMessageCreate = ({ commonsId, submitAction }) => {
 
     const testid = "ChatMessageCreate";
+    const initialMessagePageSize = 10;
+
+    const objectToAxiosParams = (newMessage) => ({
+        // Stryker disable next-line all : axiosMock post test works when mutated
+        url: `/api/chat/post?commonsId=${newMessage.commonsId}&content=${newMessage.content}`,
+        method: "POST",
+        data: newMessage
+    });
+   
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/chat/get?page=0&size=${initialMessagePageSize}&commonsId=${commonsId}`]
+    );
+
+    submitAction = submitAction || (async (data) => {
+        const escapedContent = encodeURIComponent(data.message);
+        const escapedCommonsId = encodeURIComponent(Number(commonsId));
+        const params = { content: escapedContent, commonsId: escapedCommonsId };
+        mutation.mutate(params);
+        reset();
+    });
+
+    const {
+        register,
+        formState: {errors},
+        handleSubmit,
+        reset,
+    } = useForm( );
 
     return (
-        <Form data-testid={testid} >
-            
+        <Form data-testid={testid} onSubmit={handleSubmit(submitAction)} 
+            style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Form.Control
+                data-testid={`${testid}-Message`}
+                id="message"
+                type="text"
+                {...register("message", { required: "Message cannot be empty" })}
+            />
+            <Form.Control.Feedback type="invalid">
+                {errors.message?.message}
+            </Form.Control.Feedback>
+            <Button type="submit" data-testid={`${testid}-Send`}>Send</Button>
         </Form>
     );
 };

--- a/frontend/src/stories/components/Chat/ChatMessageCreate.stories.js
+++ b/frontend/src/stories/components/Chat/ChatMessageCreate.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { rest } from 'msw';
+import ChatMessageCreate from "main/components/Chat/ChatMessageCreate";
+
+export default {
+    title: 'components/Chat/ChatMessageCreate',
+    component: ChatMessageCreate
+};
+
+const Template = (args) => {
+    return (
+        <ChatMessageCreate {...args} />
+    )
+};
+
+export const Message = Template.bind({});
+
+Message.args = {
+    commonsId: 1,
+};
+
+Message.parameters = {
+    msw: [
+        rest.post('/api/chat/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
+++ b/frontend/src/tests/components/Chat/ChatMessageCreate.test.js
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import ChatMessageCreate from "main/components/Chat/ChatMessageCreate";
+import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import AxiosMockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+describe("ChatMessageCreate", () => {
+    const commonsId = 1;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/chat/get").reply(200, { content: chatMessageFixtures.oneChatMessage });
+    });
+
+    test("renders without crashing", async () => {
+        // arrange
+        const submitAction = jest.fn();
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        //assert
+
+        await waitFor(() => {
+            expect(screen.getByText(/Send/)).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId("ChatMessageCreate-Message")).toBeInTheDocument();
+        expect(screen.getByTestId("ChatMessageCreate-Send")).toBeInTheDocument();
+
+        expect(screen.getByTestId("ChatMessageCreate")).toHaveStyle("display: flex");
+        expect(screen.getByTestId("ChatMessageCreate")).toHaveStyle("justifyContent: space-between");
+        expect(screen.getByTestId("ChatMessageCreate")).toHaveStyle("alignItems: center");
+
+    });
+
+    test("shows an error when the message input is empty", async () => {
+        // arrange
+        const submitAction = jest.fn();
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        //assert
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+
+        fireEvent.click(sendButton);
+
+        await waitFor(() => {
+            expect(screen.getByText("Message cannot be empty")).toBeInTheDocument();
+        });
+    });
+
+    test("calls the correct submit action on successful submission", async () => {
+        // arrange
+        const submitAction = jest.fn();
+        const messageText = "Hello, World!";
+
+        //act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate submitAction={submitAction}  />
+            </QueryClientProvider>
+        );
+
+        const messageInput = screen.getByTestId("ChatMessageCreate-Message");
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+
+        fireEvent.change(messageInput, {target: {value: messageText}});
+        fireEvent.click(sendButton);
+
+        // Wait for submit action to be called
+        await waitFor(() => {
+            expect(submitAction).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    test("When you fill in the message form and click submit, the right things happen", async () => {
+
+        const messageText = "Hello World";
+        const expectedMessage = {
+            content: "Hello%20World",
+            commonsId: "1",
+        };
+    
+        axiosMock.onPost("/api/chat/post?commonsId=1&content=Hello%20World")
+            .reply(200, chatMessageFixtures.oneChatMessage[0] );
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <ChatMessageCreate commonsId={commonsId} />
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Send/)).toBeInTheDocument();
+        });
+    
+        const messageInput = screen.getByTestId("ChatMessageCreate-Message");
+        const sendButton = screen.getByTestId("ChatMessageCreate-Send");
+    
+        fireEvent.change(messageInput, { target: { value: messageText } });
+        fireEvent.click(sendButton);
+    
+        await waitFor(() => 
+            expect(axiosMock.history.post.length).toBe(1)
+        );
+    
+        expect(axiosMock.history.post[0].data).toEqual(JSON.stringify(expectedMessage));
+
+        await waitFor(() =>
+            expect(messageInput.value).toEqual("")
+        );
+    
+    });
+    
+});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add the ChatMessageCreate component for use in the Chat frontend. The component is a simple form, which submits a post request to the chat api.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/8b13c480-9bb3-43cb-b507-8da8914884b8)
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/18685072/a8dcd19f-1336-404d-b94f-47540d14e361)

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #74 
