### PR TITLE
fix: add role check for /api/usercommons/commons/all

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -134,6 +134,7 @@ public class UserCommonsController extends ApiController {
     
 
     @Operation(summary = "Get all user commons for a specific commons")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/commons/all")
     public  ResponseEntity<String> getUsersCommonsByCommonsId(
         @Parameter(name="commonsId") @RequestParam Long commonsId) throws JsonProcessingException {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -375,7 +375,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
         expectedUserCommons.add(testexpectedUserCommons);
         when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
 
-        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
+        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1").with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
         verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, a role check for endpoint `/api/usercommons/commons/all` is added. Non-login users should not have the access to it.

See #80 why the check should be necessary.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->

## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #80
