### PR TITLE
Hide user backend (NEW) part 2

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -294,7 +294,7 @@ public class CommonsController extends ApiController {
 
         userCommonsRepository.delete(userCommons);
 
-        String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
+        String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumNonHiddenUsers(commonsId).orElse(0));
 
         return genericMessage(responseString);
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -27,6 +27,9 @@ public class User {
     private String hostedDomain;
     private boolean admin;
 
+    @Builder.Default
+    private boolean isHidden = false;
+
     // this is used by the frontend
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "user_commons",
@@ -42,5 +45,9 @@ public class User {
     @Override
     public String toString() {
         return String.format("User: id=%d email=%s", id, email);
+    }
+
+    public void setHidden(boolean isHidden) {
+        this.isHidden = isHidden;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -68,7 +68,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
     public static void runUpdateJobInCommons(Commons commons, CommonsPlus commonsPlus, CommonsPlusBuilderService commonsPlusBuilderService, CommonsRepository commonsRepository, UserCommonsRepository userCommonsRepository, JobContext ctx){
         ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", effectiveCapacity: " + commonsPlus.getEffectiveCapacity());
-            int numUsers = commonsRepository.getNumUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumUsers(" + commons.getId() + ")"));
+            int numUsers = commonsRepository.getNumNonHiddenUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumNonHiddenUsers(" + commons.getId() + ")"));
 
             if (numUsers==0) {
                 ctx.log("No users in this commons, skipping");

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -14,7 +14,7 @@ public interface CommonsRepository extends CrudRepository<Commons, Long> {
     @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commons.id = :commonsId")
     Optional<Integer> getNumCows(Long commonsId);
 
-    @Query("SELECT COUNT(*) FROM user_commons uc WHERE uc.commons.id = :commonsId")
-    Optional<Integer> getNumUsers(Long commonsId);
+    @Query("SELECT COUNT(*) FROM user_commons uc WHERE uc.commons.id = :commonsId AND uc.user.isHidden = false")
+    Optional<Integer> getNumNonHiddenUsers(Long commonsId);
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderService.java
@@ -20,7 +20,7 @@ public class CommonsPlusBuilderService {
 
     public CommonsPlus toCommonsPlus(Commons c) {
         Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
-        Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
+        Optional<Integer> numUsers = commonsRepository.getNumNonHiddenUsers(c.getId());
 
         return CommonsPlus.builder()
                 .commons(c)

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
@@ -57,7 +57,7 @@ public class ReportService {
                 .degradationRate(commons.getDegradationRate())
                 .belowCapacityHealthUpdateStrategy(commons.getBelowCapacityHealthUpdateStrategy())
                 .aboveCapacityHealthUpdateStrategy(commons.getAboveCapacityHealthUpdateStrategy())
-                .numUsers(commonsRepository.getNumUsers(commonsId).orElse(0))
+                .numUsers(commonsRepository.getNumNonHiddenUsers(commonsId).orElse(0))
                 .numCows(commonsRepository.getNumCows(commonsId).orElse(0))
 
                 .build();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -578,7 +578,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 
         when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(commons1));
         when(commonsRepository.getNumCows(18L)).thenReturn(Optional.of(5));
-        when(commonsRepository.getNumUsers(18L)).thenReturn(Optional.of(2));
+        when(commonsRepository.getNumNonHiddenUsers(18L)).thenReturn(Optional.of(2));
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons1))).thenReturn(commonsPlus);
 
         MvcResult response = mockMvc.perform(get("/api/commons/plus?id=18"))
@@ -811,7 +811,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
         when(commonsRepository.findById(2L)).thenReturn(Optional.of(c));
-        when(commonsRepository.getNumUsers(2L)).thenReturn(Optional.of(0));
+        when(commonsRepository.getNumNonHiddenUsers(2L)).thenReturn(Optional.of(0));
 
         MvcResult response = mockMvc
                 .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
@@ -856,7 +856,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         expectedCommonsPlus.add(CommonsPlus1);
         when(commonsRepository.findAll()).thenReturn(expectedCommons);
         when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
-        when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+        when(commonsRepository.getNumNonHiddenUsers(1L)).thenReturn(Optional.of(20));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(expectedCommons))).thenReturn(expectedCommonsPlus);
         MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
@@ -11,4 +11,11 @@ public class UserTests {
     void test_toString() {
         assertEquals("User: id=1 email=user@example.org", User.builder().id(1L).email("user@example.org").build().toString());
     }
+
+    @Test
+    void test_setHidden() {
+        User user = User.builder().id(1L).email("user@example.org").build();
+        user.setHidden(true);
+        assertEquals(true, user.isHidden());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
@@ -121,7 +121,7 @@ public class UpdateCowHealthJobIndTests {
         when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(1));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(listOfCommons))).thenReturn(listOfCommonsPlus);
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
         when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(commons));

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -108,7 +108,7 @@ public class UpdateCowHealthJobTests {
         when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(totalCows));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(numUsers));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(numUsers));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(listOfCommons))).thenReturn(listOfCommonsPlus);
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
     }
@@ -218,7 +218,7 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(List.of(userCommons1, userCommons2));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(2));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(2));
 
                 runUpdateCowHealthJob();
 
@@ -306,7 +306,7 @@ public class UpdateCowHealthJobTests {
                 when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
 
                 runUpdateCowHealthJob();
 
@@ -337,7 +337,7 @@ public class UpdateCowHealthJobTests {
                 commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
 
                 when(commonsRepository.findAll()).thenReturn(List.of(commons));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(0));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(0));
 
                 runUpdateCowHealthJob();
 
@@ -355,7 +355,7 @@ public class UpdateCowHealthJobTests {
                 setupUpdateCowHealthTestOnCommons(100, 1);
                 commons.setId(117);
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.empty());
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
 
                 var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository,
                                 userCommonsRepository,
@@ -373,7 +373,7 @@ public class UpdateCowHealthJobTests {
         void test_throws_exception_when_get_num_users_fails() {
                 setupUpdateCowHealthTestOnCommons(100, 1);
                 commons.setId(117);
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.empty());
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.empty());
 
                 var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository,
                                 userCommonsRepository,
@@ -383,7 +383,7 @@ public class UpdateCowHealthJobTests {
                         updateCowHealthJob.accept(ctx);
                 });
 
-                Assertions.assertEquals("Error calling getNumUsers(117)",
+                Assertions.assertEquals("Error calling getNumNonHiddenUsers(117)",
                                 thrown.getMessage());
         }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -112,7 +112,7 @@ public class AverageCowHealthServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(20)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
 
@@ -131,7 +131,7 @@ public class AverageCowHealthServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1,userCommons2));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(120)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
         when(userRepository.findById(43L)).thenReturn(Optional.of(user2));

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderServiceTests.java
@@ -69,7 +69,7 @@ public class CommonsPlusBuilderServiceTests {
     @Test
     void test_toCommonsPlus() {
         when(commonsRepository.getNumCows(17L)).thenReturn(Optional.of(10));
-        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(5));
+        when(commonsRepository.getNumNonHiddenUsers(17L)).thenReturn(Optional.of(5));
         CommonsPlus commonsPlus = commonsPlusBuilderService.toCommonsPlus(commons);
         assertEquals(commonsPlus, this.commonsPlus);
     }
@@ -77,7 +77,7 @@ public class CommonsPlusBuilderServiceTests {
     @Test
     void test_convertToCommonsPlus() {
         when(commonsRepository.getNumCows(17L)).thenReturn(Optional.of(10));
-        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(5));
+        when(commonsRepository.getNumNonHiddenUsers(17L)).thenReturn(Optional.of(5));
         Iterable<CommonsPlus> commonsPlusIterable = commonsPlusBuilderService.convertToCommonsPlus(Arrays.asList(commons));
         CommonsPlus commonsPlus = commonsPlusIterable.iterator().next();
         assertEquals(commonsPlus, this.commonsPlus);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -145,7 +145,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 
@@ -183,7 +183,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 
@@ -205,7 +205,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This PR is a breakdown of #85. It also contains #102 

Name of `getNumUsers` is changed to `getNumNonHiddenUsers`. Other than that, nothing is changed

## Linked Issues
<!--Issues related to the PR-->
This PR relates to #84, but this PR solely does not close it.