### PR TITLE
Hide user backend (NEW) part 5

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ApiController.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.happiercows.controllers;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.errors.NoCowsException;
 import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
+import edu.ucsb.cs156.happiercows.errors.UserHiddenException;
 import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -41,6 +42,15 @@ public abstract class ApiController {
   @ExceptionHandler({ NoCowsException.class, NotEnoughMoneyException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public Object handleBadRequest(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
+  }
+
+  @ExceptionHandler({ UserHiddenException.class })
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public Object handleForbidden(Throwable e) {
     return Map.of(
       "type", e.getClass().getSimpleName(),
       "message", e.getMessage()

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -294,7 +294,7 @@ public class CommonsController extends ApiController {
 
         userCommonsRepository.delete(userCommons);
 
-        String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
+        String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumNonHiddenUsers(commonsId).orElse(0));
 
         return genericMessage(responseString);
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.errors.UserHiddenException;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
@@ -74,6 +75,9 @@ public class CommonsController extends ApiController {
     @GetMapping("/plus")
     public CommonsPlus getCommonsPlusById(
             @Parameter(name="id") @RequestParam long id) throws JsonProcessingException {
+            if (getCurrentUser().getUser().isHidden()) {
+                throw new UserHiddenException(getCurrentUser().getUser().getId());
+            }
                 CommonsPlus commonsPlus = commonsPlusBuilderService.toCommonsPlus(commonsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id)));
 
@@ -150,6 +154,9 @@ public class CommonsController extends ApiController {
     @GetMapping("")
     public Commons getCommonsById(
             @Parameter(name="id") @RequestParam Long id) throws JsonProcessingException {
+        if (getCurrentUser().getUser().isHidden()) {
+            throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
 
         Commons commons = commonsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
@@ -222,6 +229,9 @@ public class CommonsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all-health-update-strategies")
     public ResponseEntity<String> listCowHealthUpdateStrategies() throws JsonProcessingException {
+        if (getCurrentUser().getUser().isHidden()) {
+            throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
         var result = HealthUpdateStrategyList.create();
         String body = mapper.writeValueAsString(result);
         return ResponseEntity.ok().body(body);
@@ -232,6 +242,9 @@ public class CommonsController extends ApiController {
     @PostMapping(value = "/join", produces = "application/json")
     public ResponseEntity<String> joinCommon(
             @Parameter(name="commonsId") @RequestParam Long commonsId) throws Exception {
+        if (getCurrentUser().getUser().isHidden()) {
+            throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
 
         User u = getCurrentUser().getUser();
         Long userId = u.getId();

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -44,6 +44,9 @@ public class ProfitsController extends ApiController {
     public Iterable<Profit> allProfitsByCommonsId(
             @Parameter(name="commonsId") @RequestParam Long commonsId
     ) {
+        if (getCurrentUser().getUser().isHidden()) {
+            throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
         Long userId = getCurrentUser().getUser().getId();
 
         UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -3,13 +3,13 @@ package edu.ucsb.cs156.happiercows.controllers;
 import edu.ucsb.cs156.happiercows.entities.Profit;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.errors.UserHiddenException;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,8 +27,6 @@ import java.util.List;
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
 @RestController
-@Slf4j
-
 public class ProfitsController extends ApiController {
 
     @Autowired
@@ -65,6 +63,9 @@ public class ProfitsController extends ApiController {
             @Parameter(name = "pageSize", description = "Number of records per page") @RequestParam(defaultValue = "7") int pageSize
 
     ) {
+        if (getCurrentUser().getUser().isHidden()) {
+            throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
         Long userId = getCurrentUser().getUser().getId();
 
         UserCommons userCommons = userCommonsRepository.findByCommonsIdAndUserId(commonsId, userId)

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -142,7 +142,7 @@ public class UserCommonsController extends ApiController {
 
     
 
-    @Operation(summary = "Get all user commons for a specific commons")
+    @Operation(summary = "Get all user commons for a specific commons (including hidden users)")
     @GetMapping("/commons/all")
     public  ResponseEntity<String> getUsersCommonsByCommonsId(
         @Parameter(name="commonsId") @RequestParam Long commonsId) throws JsonProcessingException {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -19,6 +19,7 @@ import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.errors.NoCowsException;
 import edu.ucsb.cs156.happiercows.errors.NotEnoughMoneyException;
+import edu.ucsb.cs156.happiercows.errors.UserHiddenException;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,6 +64,9 @@ public class UserCommonsController extends ApiController {
   @GetMapping("/forcurrentuser")
   public UserCommons getUserCommonsById(
       @Parameter(name="commonsId") @RequestParam Long commonsId) throws JsonProcessingException {
+    if (getCurrentUser().getUser().isHidden()) {
+        throw new UserHiddenException(getCurrentUser().getUser().getId());
+    }
 
     User u = getCurrentUser().getUser();
     Long userId = u.getId();
@@ -77,7 +81,9 @@ public class UserCommonsController extends ApiController {
   @PutMapping("/buy")
   public ResponseEntity<String> putUserCommonsByIdBuy(
           @Parameter(name="commonsId") @RequestParam Long commonsId) throws NotEnoughMoneyException, JsonProcessingException{
-
+        if (getCurrentUser().getUser().isHidden()) {
+          throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
         User u = getCurrentUser().getUser();
         Long userId = u.getId();
 
@@ -106,6 +112,9 @@ public class UserCommonsController extends ApiController {
   @PutMapping("/sell")
   public ResponseEntity<String> putUserCommonsByIdSell(
           @Parameter(name="commonsId") @RequestParam Long commonsId) throws NoCowsException, JsonProcessingException {
+        if (getCurrentUser().getUser().isHidden()) {
+          throw new UserHiddenException(getCurrentUser().getUser().getId());
+        }
         User u = getCurrentUser().getUser();
         Long userId = u.getId();
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -4,19 +4,24 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name="User information (admin only)")
-@RequestMapping("/api/admin/users")
+@RequestMapping("/api/admin")
 @RestController
 public class UsersController extends ApiController {
     @Autowired
@@ -25,13 +30,39 @@ public class UsersController extends ApiController {
     @Autowired
     ObjectMapper mapper;
 
-    @Operation(summary = "Get a list of all users")
+    @Operation(summary = "Get a list of all users (including hidden ones)")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("")
+    @GetMapping("/users")
     public ResponseEntity<String> users()
             throws JsonProcessingException {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Hide a specific user (including hidden ones)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping(value = "/user/hide", produces = "application/json")
+    public ResponseEntity<String> hideUser(
+    @Parameter(name="userId") @RequestParam Long userId
+    ) throws Exception {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException(User.class, userId));
+        user.setHidden(true);
+        userRepository.save(user);
+        return ResponseEntity.ok().body("{}");
+    }
+
+    @Operation(summary = "Unhide a specific user (including hidden ones)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/user/unhide")
+    public ResponseEntity<String> unhideUser(
+        @Param("userId") Long userId
+    ) throws JsonProcessingException {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException(User.class, userId));
+        user.setHidden(false);
+        userRepository.save(user);
+        return ResponseEntity.ok().body("{}");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -27,6 +27,9 @@ public class User {
     private String hostedDomain;
     private boolean admin;
 
+    @Builder.Default
+    private boolean isHidden = false;
+
     // this is used by the frontend
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "user_commons",
@@ -42,5 +45,9 @@ public class User {
     @Override
     public String toString() {
         return String.format("User: id=%d email=%s", id, email);
+    }
+
+    public void setHidden(boolean isHidden) {
+        this.isHidden = isHidden;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/errors/UserHiddenException.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/errors/UserHiddenException.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.happiercows.errors;
+
+public class UserHiddenException extends RuntimeException {
+    public UserHiddenException(long userId) {
+        super("User with id " + userId + " is hidden");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -45,7 +45,9 @@ public class MilkTheCowsJob implements JobContextConsumer {
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
             for (UserCommons userCommons : allUserCommons) {
+                // milkCows will return if the user is hidden
                 milkCows(ctx, commons, userCommons, profitRepository, userCommonsRepository);
+                // If other code added here, we need to check if the user is hidden
             }
         }
 
@@ -61,6 +63,9 @@ public class MilkTheCowsJob implements JobContextConsumer {
      */
 
     public static void milkCows(JobContext ctx, Commons commons, UserCommons userCommons, ProfitRepository profitRepository, UserCommonsRepository userCommonsRepository) {
+        if (userCommons.getUser().isHidden()) {
+            return;
+        }
         User user = userCommons.getUser();
 
         ctx.log("User: " + user.getFullName()

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobInd.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobInd.java
@@ -42,7 +42,8 @@ public class MilkTheCowsJobInd implements JobContextConsumer {
             double milkPrice = commonMilked.getMilkPrice();
             ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));
 
-            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonMilked.getId());
+            // only the non-hidden users
+            Iterable<UserCommons> allUserCommons = userCommonsRepository.findNonHiddenByCommonsId(commonMilked.getId());
 
             for (UserCommons userCommons : allUserCommons) {
                 MilkTheCowsJob.milkCows(ctx, commonMilked, userCommons, profitRepository, userCommonsRepository);

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJob.java
@@ -37,7 +37,7 @@ public class SetCowHealthJob implements JobContextConsumer {
         if (commons.isPresent()) {
             ctx.log("Commons " + commons.get().getName());
 
-            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.get().getId());
+            Iterable<UserCommons> allUserCommons = userCommonsRepository.findNonHiddenByCommonsId(commons.get().getId());
 
             for (UserCommons userCommons : allUserCommons) {
                 User user = userCommons.getUser();

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -68,7 +68,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
     public static void runUpdateJobInCommons(Commons commons, CommonsPlus commonsPlus, CommonsPlusBuilderService commonsPlusBuilderService, CommonsRepository commonsRepository, UserCommonsRepository userCommonsRepository, JobContext ctx){
         ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", effectiveCapacity: " + commonsPlus.getEffectiveCapacity());
-            int numUsers = commonsRepository.getNumUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumUsers(" + commons.getId() + ")"));
+            int numUsers = commonsRepository.getNumNonHiddenUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumNonHiddenUsers(" + commons.getId() + ")"));
 
             if (numUsers==0) {
                 ctx.log("No users in this commons, skipping");

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -38,6 +38,8 @@ public class UpdateCowHealthJob implements JobContextConsumer {
 
             Commons commons = commonsPlus.getCommons();
             
+            // accept function is the entry point for external calls,
+            // so we just need to make sure runUpdateJobInCommons handles hidden users
             runUpdateJobInCommons(commons, commonsPlus, commonsPlusBuilderService, commonsRepository, userCommonsRepository, ctx);
             
         }
@@ -76,7 +78,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
             }
 
             int carryingCapacity = commonsPlus.getEffectiveCapacity();
-            Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
+            Iterable<UserCommons> allUserCommons = userCommonsRepository.findNonHiddenByCommonsId(commons.getId());
 
             Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonsRepository.java
@@ -14,7 +14,7 @@ public interface CommonsRepository extends CrudRepository<Commons, Long> {
     @Query("SELECT sum(uc.numOfCows) from user_commons uc where uc.commons.id = :commonsId")
     Optional<Integer> getNumCows(Long commonsId);
 
-    @Query("SELECT COUNT(*) FROM user_commons uc WHERE uc.commons.id = :commonsId")
-    Optional<Integer> getNumUsers(Long commonsId);
+    @Query("SELECT COUNT(*) FROM user_commons uc WHERE uc.commons.id = :commonsId AND uc.user.isHidden = false")
+    Optional<Integer> getNumNonHiddenUsers(Long commonsId);
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProfitRepository extends CrudRepository<Profit, Long> {
+    // Caller should check if userCommons.getUser() is hidden
     Iterable<Profit> findAllByUserCommons(UserCommons userCommons);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/UserCommonsRepository.java
@@ -14,4 +14,6 @@ public interface UserCommonsRepository extends CrudRepository<UserCommons, UserC
     Optional<UserCommons> findByCommonsIdAndUserId(Long commonsId, Long userId);
     @Query("SELECT uc FROM user_commons uc WHERE uc.commons.id = :commonsId")
     Iterable<UserCommons> findByCommonsId(Long commonsId);
+    @Query("SELECT uc FROM user_commons uc WHERE uc.commons.id = :commonsId AND uc.user.isHidden = false")
+    Iterable<UserCommons> findNonHiddenByCommonsId(Long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -16,10 +16,11 @@ public class AverageCowHealthService {
     @Autowired
     UserCommonsRepository userCommonsRepository;
 
+    // Non-hidden usercommons only
     public int getTotalNumCows(Long commonsId) {
         commonsRepository.findById(commonsId).orElseThrow(() -> new IllegalArgumentException(String.format("Commons with id %d not found", commonsId)));
 
-        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findNonHiddenByCommonsId(commonsId);
 
         int totalNumCows = 0;
 
@@ -33,7 +34,7 @@ public class AverageCowHealthService {
     public double getAverageCowHealth(Long commonsId) {
         commonsRepository.findById(commonsId).orElseThrow(() -> new IllegalArgumentException(String.format("Commons with id %d not found", commonsId)));
 
-        Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
+        Iterable<UserCommons> allUserCommons = userCommonsRepository.findNonHiddenByCommonsId(commonsId);
 
         double totalHealth = 0;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderService.java
@@ -20,7 +20,7 @@ public class CommonsPlusBuilderService {
 
     public CommonsPlus toCommonsPlus(Commons c) {
         Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
-        Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
+        Optional<Integer> numUsers = commonsRepository.getNumNonHiddenUsers(c.getId());
 
         return CommonsPlus.builder()
                 .commons(c)

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserService.java
@@ -11,6 +11,7 @@ public abstract class CurrentUserService {
   public abstract User getUser();
   public abstract CurrentUser getCurrentUser();
   public abstract Collection<? extends GrantedAuthority> getRoles();
+  public abstract void setHidden(boolean hidden);
 
   public final boolean isLoggedIn() {
     return getUser() != null;

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserServiceImpl.java
@@ -98,4 +98,8 @@ public class CurrentUserServiceImpl extends CurrentUserService {
   public Collection<? extends GrantedAuthority> getRoles() {
    return grantedAuthoritiesService.getGrantedAuthorities();
   }
+
+  public void setHidden(boolean hidden) {
+    // do nothing because it's a helper in MockCurrentUserServiceImpl
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
@@ -30,6 +30,7 @@ public class ReportService {
     public Report createReport(Long commonsId) {
         Report report = createAndSaveReportHeader(commonsId);
         
+        // We also want hidden users for reports
         Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commonsId);
 
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/ReportService.java
@@ -57,7 +57,7 @@ public class ReportService {
                 .degradationRate(commons.getDegradationRate())
                 .belowCapacityHealthUpdateStrategy(commons.getBelowCapacityHealthUpdateStrategy())
                 .aboveCapacityHealthUpdateStrategy(commons.getAboveCapacityHealthUpdateStrategy())
-                .numUsers(commonsRepository.getNumUsers(commonsId).orElse(0))
+                .numUsers(commonsRepository.getNumNonHiddenUsers(commonsId).orElse(0))
                 .numCows(commonsRepository.getNumCows(commonsId).orElse(0))
 
                 .build();

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -20,12 +20,20 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
     Linear("Linear", "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
+            // if the user is hidden, we don't want to change their cow health
+            if (uC.getUser().isHidden()) {
+                return uC.getCowHealth();
+            }
             return uC.getCowHealth() - (totalCows - commonsPlus.getEffectiveCapacity()) * commonsPlus.getCommons().getDegradationRate();
         }
     },
     Constant("Constant", "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(CommonsPlus commonsPlus, UserCommons uC, int totalCows) {
+            // if the user is hidden, we don't want to change their cow health
+            if (uC.getUser().isHidden()) {
+                return uC.getCowHealth();
+            }
             if (totalCows <= commonsPlus.getEffectiveCapacity()) {
                 return uC.getCowHealth() + commonsPlus.getCommons().getDegradationRate();
             } else {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -578,7 +578,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 
         when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(commons1));
         when(commonsRepository.getNumCows(18L)).thenReturn(Optional.of(5));
-        when(commonsRepository.getNumUsers(18L)).thenReturn(Optional.of(2));
+        when(commonsRepository.getNumNonHiddenUsers(18L)).thenReturn(Optional.of(2));
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons1))).thenReturn(commonsPlus);
 
         MvcResult response = mockMvc.perform(get("/api/commons/plus?id=18"))
@@ -811,7 +811,7 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
         when(commonsRepository.findById(2L)).thenReturn(Optional.of(c));
-        when(commonsRepository.getNumUsers(2L)).thenReturn(Optional.of(0));
+        when(commonsRepository.getNumNonHiddenUsers(2L)).thenReturn(Optional.of(0));
 
         MvcResult response = mockMvc
                 .perform(delete("/api/commons/2/users/1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
@@ -856,7 +856,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         expectedCommonsPlus.add(CommonsPlus1);
         when(commonsRepository.findAll()).thenReturn(expectedCommons);
         when(commonsRepository.getNumCows(1L)).thenReturn(Optional.of(50));
-        when(commonsRepository.getNumUsers(1L)).thenReturn(Optional.of(20));
+        when(commonsRepository.getNumNonHiddenUsers(1L)).thenReturn(Optional.of(20));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(expectedCommons))).thenReturn(expectedCommonsPlus);
         MvcResult response = mockMvc.perform(get("/api/commons/allplus").contentType("application/json"))
                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -1235,6 +1236,54 @@ public class CommonsControllerTests extends ControllerTestCase {
         assertEquals(100, commonsPlus.getEffectiveCapacity());
     }
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommonPlusTest_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc.perform(get("/api/commons/plus?id=18"))
+                .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getCommons_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc.perform(get("/api/commons?id=18"))
+                .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void getHealthUpdateStrategiesTest_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc.perform(
+                get("/api/commons/all-health-update-strategies")
+        ).andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void joinCommons_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc
+        .perform(post("/api/commons/join?commonsId=2").with(csrf()))
+        .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -176,5 +177,29 @@ public class ProfitsControllerTests extends ControllerTestCase {
         assertEquals(3, jsonResponse.get("totalElements").asInt());
         assertEquals(2, jsonResponse.get("totalPages").asInt());
         assertEquals(p3.getAmount(), jsonResponse.get("content").get(0).get("amount").asDouble(), 0.01);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void get_profits_all_commons_nonexistent_using_commons_id_hiddenuser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc.perform(get("/api/profits/all/commonsid?commonsId=2").contentType("application/json"))
+                .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void get_profits_all_commons_using_commons_id_with_pagination_2_hiddenuser() throws Exception {
+        currentUserService.setHidden(true);
+        MvcResult response = mockMvc.perform(get("/api/profits/paged/commonsid?commonsId=2").contentType("application/json"))
+                .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -385,4 +386,44 @@ public class UserCommonsControllerTests extends ControllerTestCase {
 
         assertEquals(expectedJson, responseString);
     }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_getUserCommonsById_exists_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+                .andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void testBuy_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
+                .with(csrf())).andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void testSell_HiddenUser() throws Exception {
+        currentUserService.setHidden(true);
+
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
+                .with(csrf())).andExpect(status().isForbidden()).andReturn();
+        Map<String, Object> responseMap = responseToJson(response);
+        assertEquals(responseMap.get("message"), "User with id 1 is hidden");
+        assertEquals(responseMap.get("type"), "UserHiddenException");
+        currentUserService.setHidden(false);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -20,9 +21,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -73,5 +76,69 @@ public class UsersControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
 
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void test_hide_non_exsitent_user() throws Exception {
+    MvcResult response = mockMvc
+            .perform(put("/api/admin/user/hide?userId=1337").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    Map<String, Object> responseMap = responseToJson(response);
+
+    assertEquals(responseMap.get("message"), "User with id 1337 not found");
+    assertEquals(responseMap.get("type"), "EntityNotFoundException");
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void test_unhide_non_exsitent_user() throws Exception {
+    MvcResult response = mockMvc
+            .perform(put("/api/admin/user/unhide?userId=1337").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    Map<String, Object> responseMap = responseToJson(response);
+
+    assertEquals(responseMap.get("message"), "User with id 1337 not found");
+    assertEquals(responseMap.get("type"), "EntityNotFoundException");
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void test_hide_user() throws Exception {
+    User u = User.builder().id(1L).build();
+    when(userRepository.findById(1L)).thenReturn(java.util.Optional.of(u));
+
+    MvcResult response = mockMvc
+            .perform(put("/api/admin/user/hide?userId=1").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"))
+            .andExpect(status().isOk())
+            .andReturn();
+    // response = "{}"
+    assertEquals(response.getResponse().getContentAsString(), "{}");
+
+    verify(userRepository, times(1)).findById(1L);
+    verify(userRepository, times(1)).save(u);
+    assertEquals(u.isHidden(), true);
+
+    response = mockMvc
+            .perform(put("/api/admin/user/unhide?userId=1").with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertEquals(response.getResponse().getContentAsString(), "{}");
+    verify(userRepository, times(2)).findById(1L);
+    verify(userRepository, times(2)).save(u);
+    assertEquals(u.isHidden(), false);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/UserTests.java
@@ -11,4 +11,11 @@ public class UserTests {
     void test_toString() {
         assertEquals("User: id=1 email=user@example.org", User.builder().id(1L).email("user@example.org").build().toString());
     }
+
+    @Test
+    void test_setHidden() {
+        User user = User.builder().id(1L).email("user@example.org").build();
+        user.setHidden(true);
+        assertEquals(true, user.isHidden());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobIndTests.java
@@ -95,7 +95,7 @@ public class MilkTheCowsJobIndTests {
                 .build();
 
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(testCommons));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+        when(userCommonsRepository.findNonHiddenByCommonsId(testCommons.getId()))
                 .thenReturn(Arrays.asList(origUserCommons));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/SetCowHealthJobTests.java
@@ -113,7 +113,7 @@ public class SetCowHealthJobTests {
                 .build();
 
         when(commonsRepository.findById(117L)).thenReturn(Optional.of(testCommons));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+        when(userCommonsRepository.findNonHiddenByCommonsId(testCommons.getId()))
                 .thenReturn(userCommonsList);
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
@@ -121,7 +121,7 @@ public class UpdateCowHealthJobIndTests {
         when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(1));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(listOfCommons))).thenReturn(listOfCommonsPlus);
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
         when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(commons));

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobIndTests.java
@@ -118,7 +118,7 @@ public class UpdateCowHealthJobIndTests {
         commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
 
         when(commonsRepository.findAll()).thenReturn(listOfCommons);
-        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
+        when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(1));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -108,7 +108,7 @@ public class UpdateCowHealthJobTests {
         when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(totalCows));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(numUsers));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(numUsers));
         when(commonsPlusBuilderService.convertToCommonsPlus(eq(listOfCommons))).thenReturn(listOfCommonsPlus);
         when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
     }
@@ -218,7 +218,7 @@ public class UpdateCowHealthJobTests {
                                 .thenReturn(List.of(userCommons1, userCommons2));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(2));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(2));
 
                 runUpdateCowHealthJob();
 
@@ -306,7 +306,7 @@ public class UpdateCowHealthJobTests {
                 when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
 
                 runUpdateCowHealthJob();
 
@@ -337,7 +337,7 @@ public class UpdateCowHealthJobTests {
                 commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
 
                 when(commonsRepository.findAll()).thenReturn(List.of(commons));
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(0));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(0));
 
                 runUpdateCowHealthJob();
 
@@ -355,7 +355,7 @@ public class UpdateCowHealthJobTests {
                 setupUpdateCowHealthTestOnCommons(100, 1);
                 commons.setId(117);
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.empty());
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(1));
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));
 
                 var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository,
                                 userCommonsRepository,
@@ -373,7 +373,7 @@ public class UpdateCowHealthJobTests {
         void test_throws_exception_when_get_num_users_fails() {
                 setupUpdateCowHealthTestOnCommons(100, 1);
                 commons.setId(117);
-                when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.empty());
+                when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.empty());
 
                 var updateCowHealthJob = new UpdateCowHealthJob(commonsRepository,
                                 userCommonsRepository,
@@ -383,7 +383,7 @@ public class UpdateCowHealthJobTests {
                         updateCowHealthJob.accept(ctx);
                 });
 
-                Assertions.assertEquals("Error calling getNumUsers(117)",
+                Assertions.assertEquals("Error calling getNumNonHiddenUsers(117)",
                                 thrown.getMessage());
         }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -105,7 +105,7 @@ public class UpdateCowHealthJobTests {
         List<CommonsPlus> listOfCommonsPlus = List.of(commonsPlus);
         
         when(commonsRepository.findAll()).thenReturn(listOfCommons);
-        when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
+        when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(totalCows));
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(numUsers));
@@ -214,7 +214,7 @@ public class UpdateCowHealthJobTests {
                 when(commonsRepository.findAll()).thenReturn(commonsList);
                 when(commonsPlusBuilderService.convertToCommonsPlus(eq(commonsList))).thenReturn(commonsPlusList);
                 when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
-                when(userCommonsRepository.findByCommonsId(commons.getId()))
+                when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId()))
                                 .thenReturn(List.of(userCommons1, userCommons2));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
@@ -303,7 +303,7 @@ public class UpdateCowHealthJobTests {
                 when(commonsPlusBuilderService.toCommonsPlus(eq(commons))).thenReturn(commonsPlus);
 
                 when(commonsRepository.findAll()).thenReturn(List.of(commons));
-                when(userCommonsRepository.findByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
+                when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId())).thenReturn(List.of(userCommons));
                 when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(99));
                 when(userRepository.findById(1L)).thenReturn(Optional.of(user));
                 when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(1));

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -110,7 +110,7 @@ public class AverageCowHealthServiceTests {
         // arrange
 
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
-        when(userCommonsRepository.findByCommonsId(commons.getId()))
+        when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1));
         when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(20)));
@@ -129,7 +129,7 @@ public class AverageCowHealthServiceTests {
         // arrange
 
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
-        when(userCommonsRepository.findByCommonsId(commons.getId()))
+        when(userCommonsRepository.findNonHiddenByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1,userCommons2));
         when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(120)));
@@ -146,7 +146,7 @@ public class AverageCowHealthServiceTests {
 
     @Test
     void test_getAverageCowHealthThrowsException() {
-        when(userCommonsRepository.findByCommonsId(1L)).thenReturn(Arrays.asList());
+        when(userCommonsRepository.findNonHiddenByCommonsId(1L)).thenReturn(Arrays.asList());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             averageCowHealthService.getAverageCowHealth(1L);
@@ -155,7 +155,7 @@ public class AverageCowHealthServiceTests {
 
     @Test
     void test_getTotalNumCowsThrowsException() {
-        when(userCommonsRepository.findByCommonsId(1L)).thenReturn(Arrays.asList());
+        when(userCommonsRepository.findNonHiddenByCommonsId(1L)).thenReturn(Arrays.asList());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             averageCowHealthService.getTotalNumCows(1L);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTests.java
@@ -112,7 +112,7 @@ public class AverageCowHealthServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(20)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
 
@@ -131,7 +131,7 @@ public class AverageCowHealthServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons1,userCommons2));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(120)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user1));
         when(userRepository.findById(43L)).thenReturn(Optional.of(user2));

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/CommonsPlusBuilderServiceTests.java
@@ -69,7 +69,7 @@ public class CommonsPlusBuilderServiceTests {
     @Test
     void test_toCommonsPlus() {
         when(commonsRepository.getNumCows(17L)).thenReturn(Optional.of(10));
-        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(5));
+        when(commonsRepository.getNumNonHiddenUsers(17L)).thenReturn(Optional.of(5));
         CommonsPlus commonsPlus = commonsPlusBuilderService.toCommonsPlus(commons);
         assertEquals(commonsPlus, this.commonsPlus);
     }
@@ -77,7 +77,7 @@ public class CommonsPlusBuilderServiceTests {
     @Test
     void test_convertToCommonsPlus() {
         when(commonsRepository.getNumCows(17L)).thenReturn(Optional.of(10));
-        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(5));
+        when(commonsRepository.getNumNonHiddenUsers(17L)).thenReturn(Optional.of(5));
         Iterable<CommonsPlus> commonsPlusIterable = commonsPlusBuilderService.convertToCommonsPlus(Arrays.asList(commons));
         CommonsPlus commonsPlus = commonsPlusIterable.iterator().next();
         assertEquals(commonsPlus, this.commonsPlus);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/ReportServiceTests.java
@@ -145,7 +145,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 
@@ -183,7 +183,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 
@@ -205,7 +205,7 @@ class ReportServiceTests {
         when(commonsRepository.findById(17L)).thenReturn(Optional.of(commons));
         when(userCommonsRepository.findByCommonsId(commons.getId()))
                 .thenReturn(Arrays.asList(userCommons));
-        when(commonsRepository.getNumUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(commonsRepository.getNumNonHiddenUsers(commons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(commonsRepository.getNumCows(commons.getId())).thenReturn(Optional.of(Integer.valueOf(123)));
         when(userRepository.findById(42L)).thenReturn(Optional.of(user));
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.happiercows.strategies;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.services.CommonsPlusBuilderService;
 
 import org.junit.jupiter.api.Test;
@@ -22,10 +23,16 @@ class CowHealthUpdateStrategyTests {
     .capacityPerUser(20)
     .carryingCapacity(100)
     .build();
-    UserCommons user = UserCommons.builder().cowHealth(50).build();
+
+    User non_hidden_user = User.builder().id(1L).fullName("Chris Gaucho").email("test@ucsb.edu").build();
+    User hidden_user = User.builder().id(2L).fullName("Chris Gaucho").email("test@ucsb.edu").isHidden(true).build();
+
+    UserCommons user = UserCommons.builder().user(non_hidden_user).cowHealth(50).build();
+    UserCommons hiddenUser = UserCommons.builder().user(hidden_user).cowHealth(50).build();
 
     CommonsPlus commonsPlus = CommonsPlus.builder().commons(commons).totalCows(0).totalUsers(1).build();
-    
+    CommonsPlus commonsPlusHidden = CommonsPlus.builder().commons(commons).totalCows(0).totalUsers(1).build();    
+
     @Test
     void get_name_and_description() {
         assertEquals("Linear", CowHealthUpdateStrategies.Linear.name());
@@ -61,5 +68,29 @@ class CowHealthUpdateStrategyTests {
         assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 110));
         assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 100));
         assertEquals(50.0, formula.calculateNewCowHealth(commonsPlus, user, 90));
+    }
+
+    @Test
+    void test_hidden() {
+        var formula = CowHealthUpdateStrategies.Linear;
+
+        // for hidden users, the health should not change
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 110));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 100));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 90));
+
+        formula = CowHealthUpdateStrategies.Constant;
+
+        // for hidden users, the health should not change
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 110));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 100));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 90));
+
+        formula = CowHealthUpdateStrategies.Noop;
+
+        // for hidden users, the health should not change
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 110));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 100));
+        assertEquals(50.0, formula.calculateNewCowHealth(commonsPlusHidden, hiddenUser, 90));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/testconfig/MockCurrentUserServiceImpl.java
@@ -70,6 +70,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     .hostedDomain(hostedDomain)
     .admin(admin)
     .id(1L)
+    .isHidden(this.isHidden)
     .build();
     
     log.info("************** ALERT **********************");
@@ -82,6 +83,12 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     log.info("************** END ALERT ******************");
 
     return u;
+  }
+
+  private boolean isHidden = false;
+
+  public void setHidden(boolean isHidden) {
+    this.isHidden = isHidden;
   }
 
   public User getUser() {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This PR is the last breakdown of #85. It also contains #105.

Other than previous PR, this PR does:
+ Check of user's/usercommon's `isHidden` for jobs
+ Change some use of `findByCommonsId` to `findNonHiddenByCommonsId`. Not all changed so admin can still see all the UserCommons in some circumstances (e.g. generate report)

## Linked Issues
<!--Issues related to the PR-->
Closes #84 
