### PR TITLE
FIX: RecordCommonStatsJob Correctly Saves Stats in Repository

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJob.java
@@ -29,7 +29,7 @@ public class RecordCommonStatsJob implements JobContextConsumer {
 
         for (Commons commons : allCommons) {
             ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
-            CommonStats commonStats = commonStatsService.createCommonStats(commons.getId());
+            CommonStats commonStats = commonStatsService.createAndSaveCommonStats(commons.getId());
             ctx.log(String.format("CommonStats %d for commons id=%d (%s) finished.", commonStats.getId(), commons.getId(),
                     commons.getName()));
         }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
@@ -43,9 +43,9 @@ public class CommonStatsService {
     public CommonStats createAndSaveCommonStats(Long commonsId) {
         
         CommonStats stats = createCommonStats(commonsId);
-        CommonStats savedStats = commonStatsRepository.save(stats);
+        commonStatsRepository.save(stats);
 
-        return savedStats;
+        return stats;
     }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CommonStatsService.java
@@ -43,9 +43,9 @@ public class CommonStatsService {
     public CommonStats createAndSaveCommonStats(Long commonsId) {
         
         CommonStats stats = createCommonStats(commonsId);
+        CommonStats savedStats = commonStatsRepository.save(stats);
 
-        commonStatsRepository.save(stats);
-        return stats;
+        return savedStats;
     }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/RecordCommonStatsJobTests.java
@@ -46,7 +46,7 @@ public class RecordCommonStatsJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
       
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commons));      
-        when(commonStatsService.createCommonStats(17L)).thenReturn(commonStats);
+        when(commonStatsService.createAndSaveCommonStats(17L)).thenReturn(commonStats);
 
         // Act
         RecordCommonStatsJob recordCommonStatsJob = 
@@ -56,7 +56,7 @@ public class RecordCommonStatsJobTests {
         // Assert
 
         verify(commonsRepository).findAll();
-        verify(commonStatsService).createCommonStats(17L);
+        verify(commonStatsService).createAndSaveCommonStats(17L);
         
         String expected = """
             Starting record common stats job...


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we fix the functionality of CommonStats so that the stats are saved into the repository when the job is run.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

