### PR TITLE
Fix edit commons page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -5,6 +5,9 @@ import {useBackend} from "main/utils/useBackend";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
+    if (initialCommons && initialCommons.startingDate && initialCommons.startingDate.includes("T")) {
+        initialCommons.startingDate = initialCommons.startingDate.split("T")[0];
+    }
 
     // Stryker disable all
     const {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -30,7 +30,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
 
     const curr = new Date();
     // eslint-disable-next-line no-unused-vars
-    const today = curr.toISOString().substr(0, 10);
+    const today = curr.toISOString().split('T')[0];
     const DefaultVals = {
         name: "", startingBalance: "10000", cowPrice: "100",
         milkPrice: "1", degradationRate: null, carryingCapacity: null, startingDate: today

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -5,7 +5,7 @@ import {useBackend} from "main/utils/useBackend";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
-    if (initialCommons && initialCommons.startingDate && initialCommons.startingDate.includes("T")) {
+    if (initialCommons && initialCommons.startingDate) {
         initialCommons.startingDate = initialCommons.startingDate.split("T")[0];
     }
 
@@ -29,7 +29,6 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     const testid = "CommonsForm";
 
     const curr = new Date();
-    // eslint-disable-next-line no-unused-vars
     const today = curr.toISOString().split('T')[0];
     const DefaultVals = {
         name: "", startingBalance: "10000", cowPrice: "100",

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -260,6 +260,23 @@ describe("CommonsForm tests", () => {
     expect(screen.getByTestId("belowCapacityHealthUpdateStrategy-Noop")).toBeInTheDocument();
   });
 
+  it("renders correctly with date cut off", async () => {
+    axiosMock
+      .onGet("/api/commons/all-health-update-strategies")
+      .reply(200, healthUpdateStrategyListFixtures.real);
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Router>
+          <CommonsForm initialCommons={commonsFixtures.threeCommons[0]} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText(/Id/)).toBeInTheDocument();
+    expect(screen.getByTestId("CommonsForm-startingDate")).toHaveValue(commonsFixtures.threeCommons[0].startingDate);
+  });
+
   it("renders correctly when an initialCommons is not passed in", async () => {
 
     axiosMock
@@ -308,5 +325,4 @@ describe("CommonsForm tests", () => {
       );
     });
   });
-
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This PR fix the CommonsForm default input date cut off issue so that edit commons page can correctly render date.

The cause to the issue is that if there's a passed in commons, the date can be in ISO long format. We need to convert it to YYYY-MM-DD.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1027" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-4/assets/56060664/54b6cb9f-fbd7-4129-aa39-7ea3f56cd06f">


## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #10
